### PR TITLE
Inherit Schema From DataSource if not defined

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -167,6 +167,9 @@ function mixinDiscovery(MySQL) {
   MySQL.prototype.discoverModelProperties = function (table, options, cb) {
     var args = getArgs(table, options, cb);
     var owner = args.owner;
+    if(!owner){
+      owner = inheritOwnerViaDataSource.call(this);
+    }
     table = args.table;
     options = args.options;
     cb = args.cb;
@@ -217,6 +220,9 @@ function mixinDiscovery(MySQL) {
   MySQL.prototype.discoverPrimaryKeys = function (table, options, cb) {
     var args = getArgs(table, options, cb);
     var owner = args.owner;
+    if(!owner){
+      owner = inheritOwnerViaDataSource.call(this);
+    }
     table = args.table;
     options = args.options;
     cb = args.cb;
@@ -258,6 +264,9 @@ function mixinDiscovery(MySQL) {
   MySQL.prototype.discoverForeignKeys = function (table, options, cb) {
     var args = getArgs(table, options, cb);
     var owner = args.owner;
+    if(!owner){
+      owner = inheritOwnerViaDataSource.call(this);
+    }
     table = args.table;
     options = args.options;
     cb = args.cb;
@@ -301,6 +310,9 @@ function mixinDiscovery(MySQL) {
   MySQL.prototype.discoverExportedForeignKeys = function (table, options, cb) {
     var args = getArgs(table, options, cb);
     var owner = args.owner;
+    if(!owner){
+      owner = inheritOwnerViaDataSource.call(this);
+    }
     table = args.table;
     options = args.options;
     cb = args.cb;
@@ -354,5 +366,12 @@ function mixinDiscovery(MySQL) {
       default:
         return 'String';
     }
+  }
+
+  function inheritOwnerViaDataSource(){
+    if(this.dataSource && this.dataSource.settings && this.dataSource.settings.database){
+      return this.dataSource.settings.database;
+    }
+    return undefined;
   }
 }


### PR DESCRIPTION
If owner is not set via json in the discovery process, use the database
schema defined in the dataSource setting.
https://github.com/strongloop/loopback-connector-mysql/issues/59
https://github.com/strongloop/loopback-datasource-juggler/issues/361