### PR TITLE
Fixed isActual implemenation

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -691,10 +691,10 @@ MySQL.prototype.createTable = function (model, cb) {
  * @param {String[]} [models] A model name or an array of model names. If not present, apply to all models
  * @param {Function} [cb] The callback function
  */
-MySQL.prototype.isActual = function(cb) {
+MySQL.prototype.isActual = function(models, cb) {
   var self = this;
   var ok = false;
-  async.each(Object.keys(this._models), function(model, done) {
+  async.each(Object.keys(models), function(model, done) {
     var table = self.tableEscaped(model);
     self.query('SHOW FIELDS FROM ' + table, function(err, fields) {
       self.query('SHOW INDEXES FROM ' + table, function(err, indexes) {

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -693,7 +693,18 @@ MySQL.prototype.createTable = function (model, cb) {
  */
 MySQL.prototype.isActual = function(models, cb) {
   var self = this;
-  var ok = false;
+
+  if ((!cb) && ('function' === typeof models)) {
+    cb = models;
+    models = undefined;
+  }
+  // First argument is a model name
+  if ('string' === typeof models) {
+    models = [models];
+  }
+
+  models = models || Object.keys(this._models);
+  
   async.each(Object.keys(models), function(model, done) {
     var table = self.tableEscaped(model);
     self.query('SHOW FIELDS FROM ' + table, function(err, fields) {


### PR DESCRIPTION
Per https://github.com/strongloop/loopback/issues/468

However, I did notice that this does not work with json object mapping (I noticed this was a problem before as well: https://github.com/strongloop/loopback-connector-mysql/pull/29)

So if you have a property in a model as such:
```
{
  "name": "MyModel",
  "base": "PersistedModel",
  "properties": {
    "myProperty": {
      "type": "number",
      "mysql":{ "dataType":"float" }
    }
  }
  ...
}
```

Then isActual will ALWAYS return that your database is out of sync /: But I think this has more to do with the object mapping fix than this function correct?

Also, I was unable to run the test on my local, it wouldn't fully take in my MySql credentials even after hard coding them into init.js ... not sure how to do so I'll let the automated testing/builder do this