### PR TITLE
NULL date instead of NaN

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -336,6 +336,9 @@ MySQL.prototype.toDatabase = function (prop, val, forCreate) {
     if (!val.toUTCString) {
       val = new Date(val);
     }
+    if (isNaN(val.getTime())) {
+      return 'NULL';
+    }
     return '"' + dateToMysql(val) + '"';
   }
   if (prop.type === Boolean) {


### PR DESCRIPTION
An invalid date cause ```dateToMysql``` to generate ```NaN-NaN-NaN NaN:NaN:NaN``` as a result and you receive ```0000-00-00 00:00:00``` timestamp.