### PR TITLE
Allow models backed by MySQL to reference mongodb ObjectID

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -323,6 +323,9 @@ MySQL.prototype.toDatabase = function (prop, val, forCreate) {
   if (!prop) {
     return this.client.escape(val);
   }
+  if (prop.type === String) {
+    return this.client.escape(String(val));
+  }
   if (prop.type === Number) {
     if (isNaN(val)) {
       val = null;
@@ -345,16 +348,25 @@ MySQL.prototype.toDatabase = function (prop, val, forCreate) {
     return val ? 'Point(' + val.lat + ',' + val.lng + ')' : 'NULL';
   }
   if (prop.type === Object) {
-    return this.client.escape(val);
+    return this._serializeObject(val);
   }
   if (typeof prop.type === 'function') {
-    if (prop.type.modelName) {
-      // For embedded models
-      return this.client.escape(JSON.stringify(val));
-    }
-    return this.client.escape(prop.type(val));
+    return this._serializeObject(val);
   }
-  return this.client.escape(val.toString());
+  return this._serializeObject(val);
+};
+
+MySQL.prototype._serializeObject = function(obj) {
+  var val;
+  if (obj && typeof obj.toJSON === 'function') {
+    obj = obj.toJSON();
+  }
+  if (typeof obj !== 'string') {
+    val = JSON.stringify(obj);
+  } else {
+    val = obj;
+  }
+  return this.client.escape(val);
 };
 
 /*!
@@ -381,6 +393,12 @@ MySQL.prototype.fromDatabase = function (model, data) {
     }
     if (props[p]) {
       switch (props[p].type.name) {
+        case 'Number':
+          val = Number(val);
+          break;
+        case 'String':
+          val = String(val);
+          break;
         case 'Date':
           val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
           break;
@@ -393,6 +411,17 @@ MySQL.prototype.fromDatabase = function (model, data) {
             lat: val.x,
             lng: val.y
           };
+          break;
+        case 'List':
+        case 'Array':
+        case 'Object':
+        case 'JSON':
+          break;
+        default:
+          if (!Array.isArray(props[p].type) && !props[p].type.modelName) {
+            // Do not convert array and model types
+            val = props[p].type(val);
+          }
           break;
       }
     }


### PR DESCRIPTION
/to @bajtos or @ritch 

When related models, for example, Customer and Order, are backed by MongoDB and MySQL, the foreign key (customerId) on MySQL can be typed as ObjectID. The PR allows the column to be saved/loaded correctly.