### PR TITLE
Query string length for schema in characters in addition to bytes

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -144,8 +144,7 @@ function mixinDiscovery(MySQL) {
       sql = paginateSQL('SELECT table_schema AS "owner",' +
           ' table_name AS "tableName", column_name AS "columnName",' +
           ' data_type AS "dataType",' +
-          ' character_maximum_length AS "length",' +
-          ' character_octet_length AS "dataLength",' +
+          ' character_maximum_length AS "dataLength",' +
           ' numeric_precision AS "dataPrecision",' +
           ' numeric_scale AS "dataScale",' +
           ' is_nullable = \'YES\' AS "nullable"' +
@@ -157,8 +156,7 @@ function mixinDiscovery(MySQL) {
       sql = paginateSQL('SELECT table_schema AS "owner",' +
           ' table_name AS "tableName", column_name AS "columnName",' +
           ' data_type AS "dataType",' +
-          ' character_maximum_length AS "length",' +
-          ' character_octet_length AS "dataLength",' +
+          ' character_maximum_length AS "dataLength",' +
           ' numeric_precision AS "dataPrecision",' +
           ' numeric_scale AS "dataScale",' +
           ' is_nullable = \'YES\' AS "nullable"' +

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -144,6 +144,7 @@ function mixinDiscovery(MySQL) {
       sql = paginateSQL('SELECT table_schema AS "owner",' +
           ' table_name AS "tableName", column_name AS "columnName",' +
           ' data_type AS "dataType",' +
+          ' character_maximum_length AS "length",' +
           ' character_octet_length AS "dataLength",' +
           ' numeric_precision AS "dataPrecision",' +
           ' numeric_scale AS "dataScale",' +
@@ -156,6 +157,7 @@ function mixinDiscovery(MySQL) {
       sql = paginateSQL('SELECT table_schema AS "owner",' +
           ' table_name AS "tableName", column_name AS "columnName",' +
           ' data_type AS "dataType",' +
+          ' character_maximum_length AS "length",' +
           ' character_octet_length AS "dataLength",' +
           ' numeric_precision AS "dataPrecision",' +
           ' numeric_scale AS "dataScale",' +


### PR DESCRIPTION
Add a field for string length when querying model properties.
