### PR TITLE
Do not change the source values for array in where parameter

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -310,10 +310,11 @@ MySQL.prototype.toDatabase = function (prop, val, forCreate) {
         this.toDatabase(prop, val[1]);
     } else if (operator === 'inq' || operator === 'nin') {
       if (Array.isArray(val)) { //if value is array
+        var vals = new Array(val.length);
         for (var i = 0; i < val.length; i++) {
-          val[i] = this.toDatabase(prop, val[i]);
+          vals[i] = this.toDatabase(prop, val[i]);
         }
-        return val.join(',');
+        return vals.join(',');
       } else {
         return this.toDatabase(prop, val);
       }


### PR DESCRIPTION
The connector should not change the input query parameters.

else if there is hardcoded query condition, when second time run it, it will not works because the array values are "escaped".

This PR fixed it.
