### PR TITLE
Fix database transactions not working with upsert()

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -234,7 +234,7 @@ MySQL.prototype.updateOrCreate = MySQL.prototype.save =
 
     sql.merge(ParameterizedSQL.join(setValues, ','));
 
-    this.execute(sql.sql, sql.params, function(err, info) {
+    this.execute(sql.sql, sql.params, options, function(err, info) {
       if (!err && info && info.insertId) {
         data.id = info.insertId;
       }
@@ -483,4 +483,3 @@ MySQL.prototype.buildExpression = function(columnName, operator, operatorValue,
 require('./migration')(MySQL, mysql);
 require('./discovery')(MySQL, mysql);
 require('./transaction')(MySQL, mysql);
-


### PR DESCRIPTION
Implements the fix reported by @nodejsbspa in #107 in which the options passed to updateOrCreate were not passed to the execute method.