### PR TITLE
Allow migration to field types with no length

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -408,6 +408,9 @@ function mixinMigration(MySQL, mysql) {
     if (!prop) {
       return null;
     }
+    if (colType && columnMetadata && columnMetadata.dataLength === false) {
+      return colType;
+    }
     var colLength = columnMetadata && columnMetadata.dataLength ||
       prop.length || prop.limit;
     if (colType && colLength) {


### PR DESCRIPTION
Some MySQL field-types are being specified without a data length (e.g. BLOBs). Currently it is not possible to use such a custom column type in conjunction with the migrator since it will always try to create/modify a field like this:

```
    "icon": {
      "type": "string",
      "dataType": "LONGBLOB"
    }
```

with this MySQL statement, which is a syntax error:

```
ALTER TABLE `TableName` ADD COLUMN `icon` LONGBLOB(512) NULL
```

The proposed change will allow the author of a model configuration to add the field like this (note the dataLength: false):

```
    "icon": {
      "type": "string",
      "dataType": "LONGBLOB",
      "mysql": {
        "dataType": "LONGBLOB",
        "dataLength": false
      }
    }
```

This proposal is my first PR for a biggish OpenSource project and is in fact a request for help :) So if there is some better way to achieve what I am trying to do, you can happily reject his PR.
