### PR TITLE
migration: use varchar(255) when the column is indexed. Fix #36

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -469,7 +469,7 @@ function mixinMigration(MySQL, mysql) {
         // The maximum length for an ID column is 1000 bytes
         // The maximum row size is 64K
         var len = p.length || p.limit ||
-          ((p.type !== String) ? 4096 : p.id ? 255 : 512);
+          ((p.type !== String) ? 4096 : p.id || p.index ? 255 : 512);
         columnType += '(' + len + ')';
         break;
       case 'char':

--- a/test/migration.test.js
+++ b/test/migration.test.js
@@ -26,7 +26,7 @@ describe('migrations', function () {
           Extra: 'auto_increment' },
         email: {
           Field: 'email',
-          Type: 'varchar(512)',
+          Type: 'varchar(255)',
           Null: 'NO',
           Key: 'MUL',
           Default: null,


### PR DESCRIPTION
See #36
