### PR TITLE
Add `connectorCapabilities `

### DIFF
--- a/test/persistence-hooks.test.js
+++ b/test/persistence-hooks.test.js
@@ -1,4 +1,6 @@
 var should = require('./init');
 var suite = require('loopback-datasource-juggler/test/persistence-hooks.suite.js');
 
-suite(global.getDataSource(), should);
+suite(global.getDataSource(), should, {
+  replaceOrCreateReportsNewInstance: true
+});


### PR DESCRIPTION
Add `connectorCapabilities ` to let `loopback-datasource-juggler` know `loopback-connector-mysql` supports `replaceOrCreateReportsNewInstance `