### PR TITLE
Allow multipleStatements connection setting

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -104,6 +104,10 @@ function MySQL(settings) {
         options[p] = s[p];
       }
     }
+
+    if(typeof s.multipleStatements === 'boolean'){
+      options.multipleStatements = s.multipleStatements;
+    }
   }
 
   this.client = mysql.createPool(options);


### PR DESCRIPTION
Allows you to set the `multipleStatements` mysql connection setting. 

Based on old forum [posts](https://groups.google.com/forum/#!topic/loopbackjs/3dZBUa9ZXWo) this seems to have worked at some point. However it was disabled in the mysql [library](https://github.com/felixge/node-mysql/blob/master/Readme.md#multiple-statement-queries) to help with prevention of sql injection.

This small patch is coded in such a way that it preserves the default, whichever that may be, in your version of the mysql library. It does however allow you to override it if you know what you're doing.

This is particularly important if you're using stored procedures as the most common way to get data out of a call is something like:

``` sql
CALL stored_proc(in_1, in_2, @out_1, @out_2); SELECT @out_1, @out_2;
```
