### PR TITLE
fix a bug for explicit column dataType definition in automigration/au…

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -729,8 +729,8 @@ function mixinMigration(MySQL, mysql) {
 
   function columnType(p, defaultType) {
     var dt = defaultType;
-    if (p.dataType) {
-      dt = String(p.dataType);
+    if (p.mysql && p.mysql.dataType) {
+      dt = String(p.mysql.dataType);
     }
     return dt;
   }


### PR DESCRIPTION
the model definition :

"modelName": {
  "type" : "someType",
  "mysql" : {
   "dataType": "someOtherType"
  }
}
when doing auto migration / auto update, it should use someOtherTye instead of
the default map of someType.
however, there was a bug that missed the 'mysql' level for intepreting this.
this commit fixed this bug.
