### PR TITLE
Add special handling of zero date/time entries

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -405,7 +405,15 @@ MySQL.prototype.fromColumnValue = function(prop, val) {
         val = String(val);
         break;
       case 'Date':
-        val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
+
+        // MySQL allows, unless NO_ZERO_DATE is set, dummy date/time entries
+        // new Date() will return Invalid Date for those, so we need to handle
+        // those separate.
+        if (val == '0000-00-00 00:00:00') {
+          val = null;
+        } else {
+          val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
+        }
         break;
       case 'Boolean':
         val = Boolean(val);

--- a/test/migration.test.js
+++ b/test/migration.test.js
@@ -318,6 +318,23 @@ describe('migrations', function () {
     });
   });
 
+  it('should map zero dateTime into null', function (done) {
+
+    query('INSERT INTO `DateData` ' +
+      '(`dateTime`, `timestamp`) ' +
+      'VALUES("0000-00-00 00:00:00", "0000-00-00 00:00:00") ',
+      function (err, ret) {
+        should.not.exists(err);
+        DateData.findById(ret.insertId, function (err, dateData) {
+          should(dateData.dateTime)
+            .be.null();
+          should(dateData.timestamp)
+            .be.null();
+          done();
+        });
+      });
+  });
+
   it('should report errors for automigrate', function() {
     db.automigrate('XYZ', function(err) {
       assert(err);


### PR DESCRIPTION
Per MySQL docs
(http://dev.mysql.com/doc/refman/5.7/en/date-and-time-types.html):

  "MySQL permits you to store a “zero” value of '0000-00-00' as a
  “dummy date.” This is in some cases more convenient than using NULL
  values, and uses less data and index space. To disallow '0000-00-00',
  enable the NO_ZERO_DATE mode.

  “Zero” date or time values used through Connector/ODBC are converted
  automatically to NULL because ODBC cannot handle such values."

As we are not using Connector/ODBC we need to handle this ourself.