### PR TITLE
Fix to configure model index in keys field

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -185,10 +185,28 @@ function mixinMigration(MySQL, mysql) {
         // second: check multiple indexes
         var orderMatched = true;
         if (indexNames.indexOf(indexName) !== -1) {
-          m.settings.indexes[indexName].columns.split(/,\s*/).forEach(
-            function(columnName, i) {
-              if (ai[indexName].columns[i] !== columnName) orderMatched = false;
-            });
+          //check if indexes are configured as "columns"
+          if (m.settings.indexes[indexName].columns) {
+            m.settings.indexes[indexName].columns.split(/,\s*/).forEach(
+              function(columnName, i) {
+                if (ai[indexName].columns[i] !== columnName) orderMatched = false;
+              });
+          } else if (m.settings.indexes[indexName].keys) {
+            //if indexes are configured as "keys"
+            var index = 0;
+            for (var key in m.settings.indexes[indexName].keys) {
+              var sortOrder = m.settings.indexes[indexName].keys[key];
+              if (ai[indexName].columns[index] !== key) {
+                orderMatched = false;
+                break;
+              }
+              index++;
+            }
+            //if number of columns differ between new and old index
+            if (index !== ai[indexName].columns.length) {
+              orderMatched = false;
+            }
+          }
         }
         if (!orderMatched) {
           sql.push('DROP INDEX ' + self.client.escapeId(indexName));
@@ -237,13 +255,35 @@ function mixinMigration(MySQL, mysql) {
         }
         if (i.kind) {
           kind = i.kind;
+        } else if (i.options && i.options.unique && i.options.unique == true) {
+          //if index unique indicator is configured
+          kind = 'UNIQUE';
+        }
+
+        var indexedColumns = [];
+        var columns = '';
+        //if indexes are configured as "keys"
+        if (i.keys) {
+          for (var key in i.keys) {
+            if (i.keys[key] !== -1) {
+              indexedColumns.push(key);
+            } else {
+              indexedColumns.push(key + ' DESC ');
+            }
+          }
+        }
+        if (indexedColumns.length > 0) {
+          columns = indexedColumns.join(',');
+        } else if (i.columns) {
+          //if indexes are configured as "columns"
+          columns = i.columns;
         }
         if (kind && type) {
           sql.push('ADD ' + kind + ' INDEX ' + iName +
-            ' (' + i.columns + ') ' + type);
+            ' (' + columns + ') ' + type);
         } else {
           sql.push('ADD ' + kind + ' INDEX ' + type + ' ' + iName +
-            ' (' + i.columns + ')');
+            ' (' + columns + ')');
         }
       }
     });
@@ -370,23 +410,43 @@ function mixinMigration(MySQL, mysql) {
         type = 'USING ' + i.type;
       }
       if (i.kind) {
+        //if index uniqueness is configured as "kind"
         kind = i.kind;
+      } else if (i.options && i.options.unique && i.options.unique == true) {
+        //if index unique indicator is configured
+        kind = 'UNIQUE';
       }
       var indexedColumns = [];
       var indexName = this.escapeName(index);
-      if (Array.isArray(i.keys)) {
-        indexedColumns = i.keys.map(function(key) {
-          return self.columnEscaped(model, key);
-        });
+      var columns = '';
+      //if indexes are configured as "keys"
+      if (i.keys) {
+        //for each field in "keys" object
+        for (var key in i.keys) {
+          if (i.keys[key] !== -1) {
+            indexedColumns.push(key);
+          } else {
+            //mysql does not support index sorting Currently
+            //but mysql has added DESC keyword for future support
+            indexedColumns.push(key + ' DESC ');
+          }
+        }
       }
-      var columns = indexedColumns.join(',') || i.columns;
-      if (kind && type) {
-        indexClauses.push(kind + ' INDEX ' + indexName + ' (' + columns + ') ' + type);
-      } else {
-        indexClauses.push(kind + ' INDEX ' + type + ' ' + indexName + ' (' + columns + ')');
+      if (indexedColumns.length) {
+        columns = indexedColumns.join(',');
+      } else if (i.columns) {
+        columns = i.columns;
+      }
+      if (columns.length) {
+        if (kind && type) {
+          indexClauses.push(kind + ' INDEX ' +
+          indexName + ' (' + columns + ') ' + type);
+        } else {
+          indexClauses.push(kind + ' INDEX ' + type +
+          ' ' + indexName + ' (' + columns + ')');
+        }
       }
     }
-
     // Define index for each of the properties
     for (var p in definition.properties) {
       var propIndex = self.buildIndex(model, p);


### PR DESCRIPTION
This is a fix for issue #109  
for model indexes not configured per strongloop documentation 

1. the documentation wants indexes to be configured in the "keys" field in model json
but the existing connector assume index configurations to be present in the "columns" field.
2. the configuration for unique indicator is not implemented currently. 

This fix will address the above issues. The issue for index sorting not working in mysql cannot be fixed, because mysql does not support index sorting currently.

