### PR TITLE
Add support for setting default values from the model definition during a migration.

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -460,8 +460,21 @@ function mixinMigration(MySQL, mysql) {
   MySQL.prototype.buildColumnDefinition = function(model, prop) {
     var p = this.getModelDefinition(model).properties[prop];
     var line = this.columnDataType(model, prop) + ' ' +
-      (this.isNullable(p) ? 'NULL' : 'NOT NULL');
+      (this.isNullable(p) ? 'NULL' : 'NOT NULL') + ' ' +
+      this.columnDefaultValue(model, prop);
     return line;
+  };
+
+  MySQL.prototype.columnDefaultValue = function(model, property) {
+    var prop = this.getModelDefinition(model).properties[property];
+    if(prop.hasOwnProperty('default')) {
+      if(prop.type.name == 'String') {
+        return 'DEFAULT "'+prop['default']+'"';
+      } else {
+        return 'DEFAULT '+prop['default'];
+      }
+    }
+    return '';
   };
 
   MySQL.prototype.columnDataType = function(model, property) {


### PR DESCRIPTION
Hi guys,
I created this pull request in the hopes we could support default values during a migration.

I wanted to add some code to do the same for a DB discovery, but that is more difficult because it also requires a change in loopback-datasource-juggler, so I'm not exactly what to do there.

Hopefully this is of some value, please let me know if there is anything I can do to make it better.

Thanks!