### PR TITLE
Foreign key migration

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -493,8 +493,6 @@ function mixinMigration(MySQL, mysql) {
   };
 
   MySQL.prototype.buildForeignKeyDefinition = function(model, keyName) {
-    //TODO validate that these are in the same DB, etc.
-    //TODO this is probably a better place to check this than in autoupdate or buildColumnDefinitions
     var definition = this.getModelDefinition(model);
 
     var fk = definition.settings.foreignKeys[keyName];
@@ -551,13 +549,6 @@ function mixinMigration(MySQL, mysql) {
         sql.push(i);
       });
 
-//       var foreignKeys = definition.settings.foreignKeys || {};
-//       for (var fk in foreignKeys) {
-//         var constraint = self.buildForeignKeyDefinition(model, fk);
-//         if (constraint) {
-//           sql.push(constraint);
-//         }
-//       }
       return sql.join(',\n  ');
     };
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -418,15 +418,19 @@ function mixinMigration(MySQL, mysql) {
     //TODO validate that these are in the same DB, etc.
     //TODO this is probably a better place to check this than in autoupdate or buildColumnDefinitions
     var definition = this.getModelDefinition(model);
+
     var fk = definition.settings.foreignKeys[keyName];
     if (fk) {
-      var fkEntity = typeof fk.entity === 'object' ? fk.entity : {name: fk.entity}; //this.getModelDefinition(fk.entity);
+      //get the definition of the referenced object
+      var fkEntityName = (typeof fk.entity === 'object') ? fk.entity.name : fk.entity;
 
-      //TODO verify that the other model in the same DB
-      return ' CONSTRAINT ' + this.client.escapeId(fk.name) +
-        ' FOREIGN KEY (' + fk.foreignKey + ')' +
-        ' REFERENCES ' + this.tableEscaped(fkEntity.name) +
-        '(' + this.client.escapeId(fk.entityKey) + ')';
+      //verify that the other model in the same DB
+      if (this._models[fkEntityName]) {
+        return ' CONSTRAINT ' + this.client.escapeId(fk.name) +
+          ' FOREIGN KEY (' + fk.foreignKey + ')' +
+          ' REFERENCES ' + this.tableEscaped(fkEntityName) +
+          '(' + this.client.escapeId(fk.entityKey) + ')';
+      }
     }
     return '';
   };

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -42,11 +42,13 @@ function mixinMigration(MySQL, mysql) {
       var table = self.tableEscaped(model);
       self.execute('SHOW FIELDS FROM ' + table, function(err, fields) {
         self.execute('SHOW INDEXES FROM ' + table, function(err, indexes) {
-          if (!err && fields && fields.length) {
-            self.alterTable(model, fields, indexes, done);
-          } else {
-            self.createTable(model, done);
-          }
+          self.discoverForeignKeys(model, {}, function(discoverErr, foreignKeys) {
+            if (!err && fields && fields.length) {
+              self.alterTable(model, fields, indexes, foreignKeys, done);
+            } else {
+              self.createTable(model, done);
+            }
+          });
         });
       });
     }, cb);
@@ -93,14 +95,16 @@ function mixinMigration(MySQL, mysql) {
       var table = self.tableEscaped(model);
       self.execute('SHOW FIELDS FROM ' + table, function(err, fields) {
         self.execute('SHOW INDEXES FROM ' + table, function(err, indexes) {
-          self.alterTable(model, fields, indexes, function(err, needAlter) {
-            if (err) {
-              return done(err);
-            } else {
-              ok = ok || needAlter;
-              done(err);
-            }
-          }, true);
+          self.discoverForeignKeys(model, {}, function(discoverErr, foreignKeys) {
+            self.alterTable(model, fields, indexes, foreignKeys, function(err, needAlter) {
+              if (err) {
+                return done(err);
+              } else {
+                ok = ok || needAlter;
+                done(err);
+              }
+            }, true);
+          });
         });
       });
     }, function(err) {
@@ -111,7 +115,7 @@ function mixinMigration(MySQL, mysql) {
     });
   };
 
-  MySQL.prototype.alterTable = function(model, actualFields, actualIndexes, done, checkOnly) {
+  MySQL.prototype.alterTable = function(model, actualFields, actualIndexes, actualFks, done, checkOnly) {
     var self = this;
     var m = this.getModelDefinition(model);
     var propNames = Object.keys(m.properties).filter(function(name) {
@@ -120,6 +124,10 @@ function mixinMigration(MySQL, mysql) {
     var indexes = m.settings.indexes || {};
     var indexNames = Object.keys(indexes).filter(function(name) {
       return !!m.settings.indexes[name];
+    });
+    var newFks = m.settings.foreignKeys || {};
+    var newFkNames = Object.keys(newFks).filter(function(name) {
+      return !!m.settings.foreignKeys[name];
     });
     var sql = [];
     var ai = {};
@@ -159,6 +167,35 @@ function mixinMigration(MySQL, mysql) {
       }
     });
 
+    //drop foreign keys for removed fields
+    if (actualFks) {
+      var removedFks = [];
+      actualFks.forEach(function(fk) {
+        var needsToDrop = false;
+        var newFk = newFks[fk.fkName];
+        if (newFk) {
+          var fkCol = expectedColName(newFk.foreignKey);
+          var fkRefKey = expectedColNameForModel(newFk.entityKey, newFk.entity);
+          var fkRefTable = newFk.entity.name; //TODO check for mysql name
+          needsToDrop = fkCol != fk.fkColumnName ||
+                        fkRefKey != fk.pkColumnName ||
+                        fkRefTable != fk.pkTableName;
+        } else {
+          needsToDrop = true;
+        }
+
+        if (needsToDrop) {
+          sql.push('DROP FOREIGN KEY ' + fk.fkName);
+          removedFks.push(fk); //keep track that we removed these
+        }
+      });
+
+      //update out list of existing keys by removing dropped keys
+      actualFks = actualFks.filter(function(k) {
+        return removedFks.indexOf(k) == -1;
+      });
+    }
+
     // drop columns
     if (actualFields) {
       actualFields.forEach(function(f) {
@@ -177,6 +214,8 @@ function mixinMigration(MySQL, mysql) {
     aiNames.forEach(function(indexName) {
       if (indexName === 'PRIMARY' ||
         (m.properties[indexName] && self.id(model, indexName))) return;
+
+      if (newFkNames.indexOf(indexName) > -1) return; //this index is from an FK
       if (indexNames.indexOf(indexName) === -1 && !m.properties[indexName] ||
         m.properties[indexName] && !m.properties[indexName].index) {
         sql.push('DROP INDEX ' + self.client.escapeId(indexName));
@@ -293,6 +332,16 @@ function mixinMigration(MySQL, mysql) {
       }
     });
 
+    //add new foreign keys
+    if (newFkNames.length) {
+      //TODO validate that these are in the same DB, etc.
+      var oldKeyNames = actualFks.map(function(oldKey) { return oldKey.fkName; });
+      newFkNames.filter(function(key) { return !~oldKeyNames.indexOf(key); })
+        .forEach(function(key) {
+          sql.push(self.buildForeignKeyDefinition(m, key));
+        });
+    }
+
     if (sql.length) {
       var query = 'ALTER TABLE ' + self.tableEscaped(model) + ' ' +
         sql.join(',\n');
@@ -336,7 +385,11 @@ function mixinMigration(MySQL, mysql) {
     }
 
     function expectedColName(propName) {
-      var mysql = m.properties[propName].mysql;
+      return expectedColNameForModel(propName, m);
+    }
+
+    function expectedColNameForModel(propName, modelToCheck) {
+      var mysql = modelToCheck.properties[propName].mysql;
       if (typeof mysql === 'undefined') {
         return propName;
       }
@@ -346,6 +399,18 @@ function mixinMigration(MySQL, mysql) {
       }
       return colName;
     }
+  };
+
+  MySQL.prototype.buildForeignKeyDefinition = function(model, keyName) {
+    var fk = model.settings.foreignKeys[keyName];
+    if (fk) {
+      //TODO verify that the other model in the same DB
+      return ' ADD CONSTRAINT ' + this.client.escapeId(fk.name) +
+        ' FOREIGN KEY (' + fk.foreignKey + ')' +
+        ' REFERENCES ' + this.tableEscaped(fk.entity.name) +
+        '(' + this.client.escapeId(fk.entityKey) + ')';
+    }
+    return '';
   };
 
   MySQL.prototype.buildColumnDefinitions =

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -42,7 +42,7 @@ function mixinMigration(MySQL, mysql) {
       var table = self.tableEscaped(model);
       self.execute('SHOW FIELDS FROM ' + table, function(err, fields) {
         self.execute('SHOW INDEXES FROM ' + table, function(err, indexes) {
-          self.discoverForeignKeys(model, {}, function(discoverErr, foreignKeys) {
+          self.discoverForeignKeys(self.table(model), {}, function(discoverErr, foreignKeys) {
             if (!err && fields && fields.length) {
               self.alterTable(model, fields, indexes, foreignKeys, done);
             } else {
@@ -95,7 +95,7 @@ function mixinMigration(MySQL, mysql) {
       var table = self.tableEscaped(model);
       self.execute('SHOW FIELDS FROM ' + table, function(err, fields) {
         self.execute('SHOW INDEXES FROM ' + table, function(err, indexes) {
-          self.discoverForeignKeys(model, {}, function(discoverErr, foreignKeys) {
+          self.discoverForeignKeys(self.table(model), {}, function(discoverErr, foreignKeys) {
             self.alterTable(model, fields, indexes, foreignKeys, function(err, needAlter) {
               if (err) {
                 return done(err);
@@ -339,7 +339,10 @@ function mixinMigration(MySQL, mysql) {
       var oldKeyNames = actualFks.map(function(oldKey) { return oldKey.fkName; });
       newFkNames.filter(function(key) { return !~oldKeyNames.indexOf(key); })
         .forEach(function(key) {
-          sql.push(self.buildForeignKeyDefinition(m, key));
+          var constraint = self.buildForeignKeyDefinition(model, key);
+          if (constraint) {
+            sql.push('ADD ' + constraint);
+          }
         });
     }
 
@@ -412,12 +415,17 @@ function mixinMigration(MySQL, mysql) {
   };
 
   MySQL.prototype.buildForeignKeyDefinition = function(model, keyName) {
-    var fk = model.settings.foreignKeys[keyName];
+    //TODO validate that these are in the same DB, etc.
+    //TODO this is probably a better place to check this than in autoupdate or buildColumnDefinitions
+    var definition = this.getModelDefinition(model);
+    var fk = definition.settings.foreignKeys[keyName];
     if (fk) {
+      var fkEntity = typeof fk.entity === "object" ? fk.entity : {name: fk.entity}; //this.getModelDefinition(fk.entity);
+
       //TODO verify that the other model in the same DB
-      return ' ADD CONSTRAINT ' + this.client.escapeId(fk.name) +
+      return ' CONSTRAINT ' + this.client.escapeId(fk.name) +
         ' FOREIGN KEY (' + fk.foreignKey + ')' +
-        ' REFERENCES ' + this.tableEscaped(fk.entity.name) +
+        ' REFERENCES ' + this.tableEscaped(fkEntity.name) +
         '(' + this.client.escapeId(fk.entityKey) + ')';
     }
     return '';
@@ -460,6 +468,14 @@ function mixinMigration(MySQL, mysql) {
       indexes.forEach(function(i) {
         sql.push(i);
       });
+
+//       var foreignKeys = definition.settings.foreignKeys || {};
+//       for (var fk in foreignKeys) {
+//         var constraint = self.buildForeignKeyDefinition(model, fk);
+//         if (constraint) {
+//           sql.push(constraint);
+//         }
+//       }
       return sql.join(',\n  ');
     };
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -129,6 +129,7 @@ function mixinMigration(MySQL, mysql) {
     var newFkNames = Object.keys(newFks).filter(function(name) {
       return !!m.settings.foreignKeys[name];
     });
+    var dropConstraintSql = [];
     var sql = [];
     var ai = {};
 
@@ -185,7 +186,7 @@ function mixinMigration(MySQL, mysql) {
         }
 
         if (needsToDrop) {
-          sql.push('DROP FOREIGN KEY ' + fk.fkName);
+          dropConstraintSql.push('DROP FOREIGN KEY ' + fk.fkName);
           removedFks.push(fk); //keep track that we removed these
         }
       });
@@ -342,13 +343,22 @@ function mixinMigration(MySQL, mysql) {
         });
     }
 
-    if (sql.length) {
-      var query = 'ALTER TABLE ' + self.tableEscaped(model) + ' ' +
-        sql.join(',\n');
+    if (sql.length || dropConstraintSql.length) {
+      var stmtList = [dropConstraintSql, sql]
+        .filter(function(stmts) { return stmts.length; })
+        .map(function(statements) {
+          return 'ALTER TABLE ' + self.tableEscaped(model) +
+            ' ' + statements.join(',\n');
+        });
+
       if (checkOnly) {
-        done(null, true, {statements: sql, query: query});
+        done(null, true, {statements: stmtList, query: stmtList.join(';')});
       } else {
-        this.execute(query, done);
+        async.eachSeries(stmtList, function(stmt, execDone) {
+          self.execute(stmt, execDone);
+        }, function(err) {
+          done(err);
+        });
       }
     } else {
       done();

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -420,7 +420,7 @@ function mixinMigration(MySQL, mysql) {
     var definition = this.getModelDefinition(model);
     var fk = definition.settings.foreignKeys[keyName];
     if (fk) {
-      var fkEntity = typeof fk.entity === "object" ? fk.entity : {name: fk.entity}; //this.getModelDefinition(fk.entity);
+      var fkEntity = typeof fk.entity === 'object' ? fk.entity : {name: fk.entity}; //this.getModelDefinition(fk.entity);
 
       //TODO verify that the other model in the same DB
       return ' CONSTRAINT ' + this.client.escapeId(fk.name) +

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -41,8 +41,14 @@ function mixinMigration(MySQL, mysql) {
       }
       var table = self.tableEscaped(model);
       self.execute('SHOW FIELDS FROM ' + table, function(err, fields) {
+        if (err) console.log('Failed to discover "' + table + '" fields', err);
+
         self.execute('SHOW INDEXES FROM ' + table, function(err, indexes) {
-          self.discoverForeignKeys(self.table(model), {}, function(discoverErr, foreignKeys) {
+          if (err) console.log('Failed to discover "' + table + '" indexes', err);
+
+          self.discoverForeignKeys(self.table(model), {}, function(err, foreignKeys) {
+            if (err) console.log('Failed to discover "' + table + '" foreign keys', err);
+
             if (!err && fields && fields.length) {
               self.alterTable(model, fields, indexes, foreignKeys, done);
             } else {
@@ -94,8 +100,14 @@ function mixinMigration(MySQL, mysql) {
     async.each(models, function(model, done) {
       var table = self.tableEscaped(model);
       self.execute('SHOW FIELDS FROM ' + table, function(err, fields) {
+        if (err) console.log('Failed to discover "' + table + '" fields', err);
+
         self.execute('SHOW INDEXES FROM ' + table, function(err, indexes) {
-          self.discoverForeignKeys(self.table(model), {}, function(discoverErr, foreignKeys) {
+          if (err) console.log('Failed to discover "' + table + '" indexes', err);
+
+          self.discoverForeignKeys(self.table(model), {}, function(err, foreignKeys) {
+            if (err) console.log('Failed to discover "' + table + '" foreign keys', err);
+
             self.alterTable(model, fields, indexes, foreignKeys, function(err, needAlter) {
               if (err) {
                 return done(err);

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -21,6 +21,7 @@ function mixinMigration(MySQL, mysql) {
    */
   MySQL.prototype.autoupdate = function(models, cb) {
     var self = this;
+    var foreignKeyStatements = [];
 
     if ((!cb) && ('function' === typeof models)) {
       cb = models;
@@ -50,14 +51,46 @@ function mixinMigration(MySQL, mysql) {
             if (err) console.log('Failed to discover "' + table + '" foreign keys', err);
 
             if (!err && fields && fields.length) {
-              self.alterTable(model, fields, indexes, foreignKeys, done);
+              //if we already have a definition, update this table
+              self.alterTable(model, fields, indexes, foreignKeys, function(err, changed, res) {
+                //check to see if there were any new foreign keys for this table.
+                //If so, we'll create them once all tables have been updated
+                if (!err && res && res.newFks && res.newFks.length) {
+                  foreignKeyStatements.push(res.newFks);
+                }
+
+                done(err);
+              });
             } else {
-              self.createTable(model, done);
+              //if there is not yet a definition, create this table
+              var res = self.createTable(model, function(err) {
+                if (!err) {
+                  //get a list of the alter statements needed to add the defined foreign keys
+                  var newFks = self.getForeignKeySQL(model, foreignKeys);
+
+                  //check to see if there were any new foreign keys for this table.
+                  //If so, we'll create them once all tables have been updated
+                  if (newFks && newFks.length) {
+                    foreignKeyStatements.push(self.getAlterStatement(model, newFks));
+                  }
+                }
+
+                done(err);
+              });
             }
           });
         });
       });
-    }, cb);
+    }, function(err) {
+      if (err) return cb(err);
+
+      //add any new foreign keys
+      async.each(foreignKeyStatements, function(addFkStmt, execDone) {
+        self.execute(addFkStmt, execDone);
+      }, function(err) {
+        cb(err);
+      });
+    });
   };
 
   /*!
@@ -120,11 +153,33 @@ function mixinMigration(MySQL, mysql) {
         });
       });
     }, function(err) {
-      if (err) {
-        return err;
-      }
-      cb(null, !ok);
+      cb(err, !ok);
     });
+  };
+
+  MySQL.prototype.getForeignKeySQL = function(model, actualFks) {
+    var self = this;
+    var m = this.getModelDefinition(model);
+    var addFksSql = [];
+    var newFks = m.settings.foreignKeys || {};
+    var newFkNames = Object.keys(newFks).filter(function(name) {
+      return !!m.settings.foreignKeys[name];
+    });
+
+    //add new foreign keys
+    if (newFkNames.length) {
+      //narrow down our key names to only those that don't already exist
+      var oldKeyNames = actualFks.map(function(oldKey) { return oldKey.fkName; });
+      newFkNames.filter(function(key) { return !~oldKeyNames.indexOf(key); })
+        .forEach(function(key) {
+          var constraint = self.buildForeignKeyDefinition(model, key);
+          if (constraint) {
+            addFksSql.push('ADD ' + constraint);
+          }
+        });
+    }
+
+    return addFksSql;
   };
 
   MySQL.prototype.alterTable = function(model, actualFields, actualIndexes, actualFks, done, checkOnly) {
@@ -143,11 +198,9 @@ function mixinMigration(MySQL, mysql) {
     var indexNames = Object.keys(indexes).filter(function(name) {
       return !!m.settings.indexes[name];
     });
-    var newFks = m.settings.foreignKeys || {};
-    var newFkNames = Object.keys(newFks).filter(function(name) {
-      return !!m.settings.foreignKeys[name];
-    });
-    var dropConstraintSql = [];
+
+    //add new foreign keys
+    var correctFks = m.settings.foreignKeys || {};
     var sql = [];
     var ai = {};
 
@@ -191,10 +244,11 @@ function mixinMigration(MySQL, mysql) {
       var removedFks = [];
       actualFks.forEach(function(fk) {
         var needsToDrop = false;
-        var newFk = newFks[fk.fkName];
+        var newFk = correctFks[fk.fkName];
         if (newFk) {
           var fkCol = expectedColName(newFk.foreignKey);
-          var fkRefKey = expectedColNameForModel(newFk.entityKey, newFk.entity);
+          var fkEntity = self.getModelDefinition(newFk.entity);
+          var fkRefKey = expectedColNameForModel(newFk.entityKey, fkEntity);
           var fkRefTable = newFk.entity.name; //TODO check for mysql name
           needsToDrop = fkCol != fk.fkColumnName ||
                         fkRefKey != fk.pkColumnName ||
@@ -204,7 +258,7 @@ function mixinMigration(MySQL, mysql) {
         }
 
         if (needsToDrop) {
-          dropConstraintSql.push('DROP FOREIGN KEY ' + fk.fkName);
+          sql.push('DROP FOREIGN KEY ' + fk.fkName);
           removedFks.push(fk); //keep track that we removed these
         }
       });
@@ -234,7 +288,7 @@ function mixinMigration(MySQL, mysql) {
       if (indexName === 'PRIMARY' ||
         (m.properties[indexName] && self.id(model, indexName))) return;
 
-      if (newFkNames.indexOf(indexName) > -1) return; //this index is from an FK
+      if (Object.keys(actualFks).indexOf(indexName) > -1) return; //this index is from an FK
       if (indexNames.indexOf(indexName) === -1 && !m.properties[indexName] ||
         m.properties[indexName] && !m.properties[indexName].index) {
         sql.push('DROP INDEX ' + self.client.escapeId(indexName));
@@ -351,34 +405,34 @@ function mixinMigration(MySQL, mysql) {
       }
     });
 
-    //add new foreign keys
-    if (newFkNames.length) {
-      //TODO validate that these are in the same DB, etc.
-      var oldKeyNames = actualFks.map(function(oldKey) { return oldKey.fkName; });
-      newFkNames.filter(function(key) { return !~oldKeyNames.indexOf(key); })
-        .forEach(function(key) {
-          var constraint = self.buildForeignKeyDefinition(model, key);
-          if (constraint) {
-            sql.push('ADD ' + constraint);
-          }
-        });
-    }
+    //since we're passing the actualFks list to this,
+    //this code has be called after foreign keys have been dropped
+    //(in case we're replacing FKs)
+    var addFksSql = this.getForeignKeySQL(model, actualFks);
 
-    if (sql.length || dropConstraintSql.length) {
-      var stmtList = [dropConstraintSql, sql]
-        .filter(function(stmts) { return stmts.length; })
-        .map(function(statements) {
-          return 'ALTER TABLE ' + self.tableEscaped(model) +
-            ' ' + statements.join(',\n');
-        });
+    //determine if there are column, index, or foreign keys changes (all require update)
+    if (sql.length || addFksSql.length) {
+      //get the required alter statements
+      var alterStmt = self.getAlterStatement(model, sql);
+      var newFksStatement = self.getAlterStatement(model, addFksSql);
+      var stmtList = [alterStmt, newFksStatement].filter(function(s) { return s.length; });
 
-      if (checkOnly) {
-        done(null, true, {statements: stmtList, query: stmtList.join(';')});
+      //set up an object to pass back all changes, changes that have been run,
+      //and foreign key statements that haven't been run
+      var retValues = {
+        statements: stmtList,
+        query: stmtList.join(';'),
+        newFks: newFksStatement,
+      };
+
+      //if we're running in read only mode OR if the only changes are foreign keys additions,
+      //then just return the object directly
+      if (checkOnly || !alterStmt.length) {
+        done(null, true, retValues);
       } else {
-        async.eachSeries(stmtList, function(stmt, execDone) {
-          self.execute(stmt, execDone);
-        }, function(err) {
-          done(err);
+        //if there are changes in the alter statement, then execute them and return the object
+        self.execute(alterStmt, function(err) {
+          done(err, true, retValues);
         });
       }
     } else {
@@ -430,6 +484,12 @@ function mixinMigration(MySQL, mysql) {
       }
       return colName;
     }
+  };
+
+  MySQL.prototype.getAlterStatement = function(model, statements) {
+    return statements.length ?
+      'ALTER TABLE ' + this.tableEscaped(model) + ' ' + statements.join(',\n') :
+      '';
   };
 
   MySQL.prototype.buildForeignKeyDefinition = function(model, keyName) {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -116,6 +116,12 @@ function mixinMigration(MySQL, mysql) {
   };
 
   MySQL.prototype.alterTable = function(model, actualFields, actualIndexes, actualFks, done, checkOnly) {
+    //if this is using an old signature, then grab the correct callback and check boolean
+    if ('function' == typeof actualFks && typeof done !== 'function') {
+      checkOnly = done || false;
+      done = actualFks;
+    }
+
     var self = this;
     var m = this.getModelDefinition(model);
     var propNames = Object.keys(m.properties).filter(function(name) {


### PR DESCRIPTION
@superkhau Here is a beginning to supporting foreign keys in autoupdate/automigrate (per https://github.com/strongloop/loopback-connector-mysql/issues/135).

This does build and drop the database side foreign keys when foreign keys are defined on the model. (I have a [fork of the datasource juggler](https://github.com/matthewdickinson/loopback-datasource-juggler/commits/foreign_key_generation) that exposes the foreign keys via the `settings` for the model, but I wasn't sure what the best way to connect that is.)

These are the items that I know could happen/be issues
- Trying to build a foreign key across datasources (I haven't yet added anything to bar a user from creating a foreign key setting that will break)
- Currently, this code will not add foreign keys when creating tables. A second call to autoupdate is required with the current code. I see a couple possible ways to fix this.
  1. Run `SET FOREIGN_KEY_CHECKS=0;` at the beginning of automigrate and `SET FOREIGN_KEY_CHECKS=1;` at the end.
  2. Enforce some sort of order to the table creation so that a model is not run through create until after its dependencies have been created (this sounds difficult).
  3. Automatically re-run the foreign key code at the end of automigrate/autoupdate if there are any new tables
- Should there be a setting to not create foreign keys even if relations are being used?

NOTE: I did add a new set of tests to validate that the foreign keys build and drop correctly. However, per the issue above, I have to back-to-back call automigrate and autoupdate to get the foreign keys to build for the new model.

Let me know what more I can do, what I should change, which direction should be pursued for enabling foreign keys on table creation, etc.
