### PR TITLE
Remove unused prefix for test env vars

### DIFF
--- a/test/init.js
+++ b/test/init.js
@@ -13,10 +13,8 @@ var config = require('rc')('loopback', {test: {mysql: {}}}).test.mysql;
 console.log(config);
 global.getConfig = function(options) {
   var dbConf = {
-    host: process.env.TEST_MYSQL_HOST || process.env.MYSQL_HOST ||
-      config.host || 'localhost',
-    port: process.env.TEST_MYSQL_PORT || process.env.MYSQL_PORT ||
-      config.port || 3306,
+    host: process.env.MYSQL_HOST || config.host || 'localhost',
+    port: process.env.MYSQL_PORT || config.port || 3306,
     database: 'myapp_test',
     username: process.env.MYSQL_USER || config.username,
     password: process.env.MYSQL_PASSWORD || config.password,


### PR DESCRIPTION
* TEST_ prefix is not used by CI anymore and there for serve no purpose

* Part of overall goal to standardize env var injection to
  MODULE_VARNAME (ie. MYSQL_HOST for example) convention

@rmg PTAL

cc @bajtos @strongloop/fa-db-connectors 