### PR TITLE
Fixed the different column name in datasource

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -307,10 +307,8 @@ function mixinMigration(MySQL, mysql) {
     function actualize(propName, oldSettings) {
       var newSettings = m.properties[propName];
       if (newSettings && changed(newSettings, oldSettings)) {
-      // Check if the property has a different column name in the database (other than property name)
-        var pName;
-        if (newSettings.mysql && newSettings.mysql.columnName) pName = newSettings.mysql.columnName;
-        else pName = self.client.escapeId(propName);
+        // Check if the property has a different column name in the database (other than property name)
+        var pName = (newSettings.mysql && newSettings.mysql.columnName) || self.client.escapeId(propName);
         sql.push('CHANGE COLUMN ' + pName + ' ' + pName + ' ' +
           self.buildColumnDefinition(model, propName));
       }

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -307,13 +307,11 @@ function mixinMigration(MySQL, mysql) {
     function actualize(propName, oldSettings) {
       var newSettings = m.properties[propName];
       if (newSettings && changed(newSettings, oldSettings)) {
-
       // Check if the property has a different column name in the database (other than property name)
-      var pName;
-      if(newSettings.mysql && newSettings.mysql.columnName) pName = newSettings.mysql.columnName;
-      else pName = self.client.escapeId(propName);
-
-      sql.push('CHANGE COLUMN ' + pName + ' ' + pName + ' ' +
+        var pName;
+        if (newSettings.mysql && newSettings.mysql.columnName) pName = newSettings.mysql.columnName;
+        else pName = self.client.escapeId(propName);
+        sql.push('CHANGE COLUMN ' + pName + ' ' + pName + ' ' +
           self.buildColumnDefinition(model, propName));
       }
     }

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -307,8 +307,13 @@ function mixinMigration(MySQL, mysql) {
     function actualize(propName, oldSettings) {
       var newSettings = m.properties[propName];
       if (newSettings && changed(newSettings, oldSettings)) {
-        var pName = self.client.escapeId(propName);
-        sql.push('CHANGE COLUMN ' + pName + ' ' + pName + ' ' +
+
+      // Check if the property has a different column name in the database (other than property name)
+      var pName;
+      if(newSettings.mysql && newSettings.mysql.columnName) pName = newSettings.mysql.columnName;
+      else pName = self.client.escapeId(propName);
+
+      sql.push('CHANGE COLUMN ' + pName + ' ' + pName + ' ' +
           self.buildColumnDefinition(model, propName));
       }
     }

--- a/test/mysql.autoupdate.test.js
+++ b/test/mysql.autoupdate.test.js
@@ -222,12 +222,6 @@ describe('MySQL connector', function() {
 
   it('should update the nullable property of "first_name" to false', function(done) {
     // update the model "required" property
-    updateSchemaColRenameTest();
-    // nullable should be updated to false
-    updateProperty(done);
-  });
-
-  function updateSchemaColRenameTest() {
     var schema = {
       name: 'ColRenameTest',
       options: {
@@ -257,9 +251,8 @@ describe('MySQL connector', function() {
     };
 
     ds.createModel(schema.name, schema.properties, schema.options);
-  }
 
-  function updateProperty(done) {
+    // nullable should be updated to false
     ds.autoupdate('ColRenameTest', function(err) {
       assert.ifError(err);
       ds.discoverModelProperties('col_rename_test', function(err, props) {
@@ -268,7 +261,7 @@ describe('MySQL connector', function() {
         done();
       });
     });
-  }
+  });
 
   function verifyMysqlColumnNameAutoupdate(done) {
     ds.autoupdate('ColRenameTest', function(err) {

--- a/test/mysql.autoupdate.test.js
+++ b/test/mysql.autoupdate.test.js
@@ -18,99 +18,97 @@ describe('MySQL connector', function() {
   });
 
   it('should auto migrate/update tables', function(done) {
-    var schema_v1 =
-      {
-        'name': 'CustomerTest',
-        'options': {
-          'idInjection': false,
-          'mysql': {
-            'schema': 'myapp_test',
-            'table': 'customer_test',
-          },
-          'indexes': {
-            'name_index': {
-              'keys': {
-                'name': 1,
-              },
-              'options': {
-                'unique': true,
-              },
+    var schema_v1 = {
+      'name': 'CustomerTest',
+      'options': {
+        'idInjection': false,
+        'mysql': {
+          'schema': 'myapp_test',
+          'table': 'customer_test',
+        },
+        'indexes': {
+          'name_index': {
+            'keys': {
+              'name': 1,
+            },
+            'options': {
+              'unique': true,
             },
           },
         },
-        'properties': {
-          'id': {
-            'type': 'String',
-            'length': 20,
-            'id': 1,
-          },
-          'name': {
-            'type': 'String',
-            'required': false,
-            'length': 40,
-          },
-          'email': {
-            'type': 'String',
-            'required': true,
-            'length': 40,
-          },
-          'age': {
-            'type': 'Number',
-            'required': false,
-          },
+      },
+      'properties': {
+        'id': {
+          'type': 'String',
+          'length': 20,
+          'id': 1,
         },
-      };
+        'name': {
+          'type': 'String',
+          'required': false,
+          'length': 40,
+        },
+        'email': {
+          'type': 'String',
+          'required': true,
+          'length': 40,
+        },
+        'age': {
+          'type': 'Number',
+          'required': false,
+        },
+      },
+    };
 
-    var schema_v2 =
-      {
-        'name': 'CustomerTest',
-        'options': {
-          'idInjection': false,
+    var schema_v2 = {
+      'name': 'CustomerTest',
+      'options': {
+        'idInjection': false,
+        'mysql': {
+          'schema': 'myapp_test',
+          'table': 'customer_test',
+        },
+        'indexes': {
+          'updated_name_index': {
+            'keys': {
+              'firstName': 1,
+              'lastName': -1,
+            },
+            'options': {
+              'unique': true,
+            },
+          },
+        },
+      },
+      'properties': {
+        'id': {
+          'type': 'String',
+          'length': 20,
+          'id': 1,
+        },
+        'email': {
+          'type': 'String',
+          'required': false,
+          'length': 60,
           'mysql': {
-            'schema': 'myapp_test',
-            'table': 'customer_test',
-          },
-          'indexes': {
-            'updated_name_index': {
-              'keys': {
-                'firstName': 1,
-                'lastName': -1,
-              },
-              'options': {
-                'unique': true,
-              },
-            },
+            'columnName': 'email',
+            'dataType': 'varchar',
+            'dataLength': 60,
+            'nullable': 'YES',
           },
         },
-        'properties': {
-          'id': {
-            'type': 'String',
-            'length': 20,
-            'id': 1,
-          },
-          'email': {
-            'type': 'String',
-            'required': false,
-            'length': 60,
-            'mysql': {
-              'columnName': 'email',
-              'dataType': 'varchar',
-              'dataLength': 60,
-              'nullable': 'YES',
-            },
-          },
-          'firstName': {
-            'type': 'String',
-            'required': false,
-            'length': 40,
-          },
-          'lastName': {
-            'type': 'String',
-            'required': false,
-            'length': 40,
-          },
+        'firstName': {
+          'type': 'String',
+          'required': false,
+          'length': 40,
         },
-      };
+        'lastName': {
+          'type': 'String',
+          'required': false,
+          'length': 40,
+        },
+      },
+    };
 
     ds.createModel(schema_v1.name, schema_v1.properties, schema_v1.options);
 
@@ -130,16 +128,16 @@ describe('MySQL connector', function() {
         assert.equal(names[3], 'age');
 
         ds.connector.execute('SHOW INDEXES FROM customer_test', function(err, indexes) {
-          if (err) return done (err);
+          if (err) return done(err);
           assert(indexes);
           assert(indexes.length.should.be.above(1));
           assert.equal(indexes[1].Key_name, 'name_index');
           assert.equal(indexes[1].Non_unique, 0);
           ds.createModel(schema_v2.name, schema_v2.properties, schema_v2.options);
           ds.autoupdate(function(err, result) {
-            if (err) return done (err);
+            if (err) return done(err);
             ds.discoverModelProperties('customer_test', function(err, props) {
-              if (err) return done (err);
+              if (err) return done(err);
               assert.equal(props.length, 4);
               var names = props.map(function(p) {
                 return p.columnName;
@@ -149,7 +147,7 @@ describe('MySQL connector', function() {
               assert.equal(names[2], 'firstName');
               assert.equal(names[3], 'lastName');
               ds.connector.execute('SHOW INDEXES FROM customer_test', function(err, updatedindexes) {
-                if (err) return done (err);
+                if (err) return done(err);
                 assert(updatedindexes);
                 assert(updatedindexes.length.should.be.above(2));
                 assert.equal(updatedindexes[1].Key_name, 'updated_name_index');
@@ -221,6 +219,56 @@ describe('MySQL connector', function() {
     // second autoupdate call uses alter table
     verifyMysqlColumnNameAutoupdate(done);
   });
+
+  it('should update the nullable property of "first_name" to false', function(done) {
+    // update the model "required" property
+    updateSchemaColRenameTest();
+    // nullable should be updated to false
+    updateProperty(done);
+  });
+
+  function updateSchemaColRenameTest() {
+    var schema = {
+      name: 'ColRenameTest',
+      options: {
+        idInjection: false,
+        mysql: {
+          schema: 'myapp_test',
+          table: 'col_rename_test',
+        },
+      },
+      properties: {
+        firstName: {
+          type: 'String',
+          required: true,
+          length: 40,
+          mysql: {
+            columnName: 'first_name',
+            dataType: 'varchar',
+            dataLength: 40,
+          },
+        },
+        lastName: {
+          type: 'String',
+          required: false,
+          length: 40,
+        },
+      },
+    };
+
+    ds.createModel(schema.name, schema.properties, schema.options);
+  }
+
+  function updateProperty(done) {
+    ds.autoupdate('ColRenameTest', function(err) {
+      assert.ifError(err);
+      ds.discoverModelProperties('col_rename_test', function(err, props) {
+        assert.equal(props[0].nullable, 'N');
+        assert.equal(props[0].columnName, 'first_name');
+        done();
+      });
+    });
+  }
 
   function verifyMysqlColumnNameAutoupdate(done) {
     ds.autoupdate('ColRenameTest', function(err) {


### PR DESCRIPTION
Issue #250

connect to https://github.com/strongloop/loopback-connector-mysql/issues/250

### Description
 Fixed the issue with autoupdating caused by different columns specs.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #250 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

I found no need to create new tests for this. If necessary, I will but please give me a few info.