### PR TITLE
Fix async.each in migration

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -58,7 +58,7 @@ function mixinMigration(MySQL, mysql) {
 
     models = models || Object.keys(this._models);
 
-    async.each(models, function(model, done) {
+    async.eachSeries(models, function(model, done) {
       if (!(model in self._models)) {
         return process.nextTick(function() {
           done(new Error(g.f('Model not found: %s', model)));
@@ -136,7 +136,7 @@ function mixinMigration(MySQL, mysql) {
 
     models = models || Object.keys(this._models);
 
-    async.each(models, function(model, done) {
+    async.eachSeries(models, function(model, done) {
       self.getTableStatus(model, function(err, fields, indexes) {
         self.discoverForeignKeys(self.table(model), {}, function(err, foreignKeys) {
           if (err) console.log('Failed to discover "' + table + '" foreign keys', err);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "debug": "^2.1.1",
-    "loopback-connector": "^4.0.0",
+    "loopback-connector": "dagams/loopback-connector",
     "mysql": "^2.11.1",
     "strong-globalize": "^2.5.8"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "debug": "^2.1.1",
-    "loopback-connector": "dagams/loopback-connector",
+    "loopback-connector": "^4.0.0",
     "mysql": "^2.11.1",
     "strong-globalize": "^2.5.8"
   },


### PR DESCRIPTION
### Description

The problem is that FK constraints require a certain table to exist, otherwise the SQL will fail.
I switched from `each` to `eachSeries` so that at least, I can influence the order in wich tables
are processed manually in my migration boot script.

A better solution would be to first finish creating tables, then deal with foreign keys separately.
This would also fix the issue of circular references (TableA -> Table B, TableB -> TableA).

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
