### PR TITLE
legacyDateTypeProcessing flag for datetime processing

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -135,9 +135,6 @@ function generateOptions(settings) {
       charset: s.collation.toUpperCase(), // Correct by docs despite seeming odd.
       supportBigNumbers: s.supportBigNumbers,
       connectionLimit: s.connectionLimit,
-      //prevent mysqljs from converting DATE, DATETIME and TIMESTAMP types
-      //to javascript Date object
-      dateStrings: true,
     };
 
     // Don't configure the DB if the pool can be used for multiple DBs
@@ -155,6 +152,11 @@ function generateOptions(settings) {
         options[p] = s[p];
       }
     }
+    //discussed in #257
+    //prevent mysqljs from converting DATE, DATETIME and TIMESTAMP types
+    //to javascript Date object
+    if (s.legacyDateTypeProcessing === undefined) s.legacyDateTypeProcessing = true;
+    if (!s.legacyDateTypeProcessing) options.dateStrings = true;
   }
   return options;
 }
@@ -382,14 +384,15 @@ MySQL.prototype.toColumnValue = function(prop, val) {
     if (!val.toUTCString) {
       val = new Date(val);
     }
+    if (this.settings.legacyDateTypeProcessing)
+      return dateToMysql(val, 'Z');
+
 
     if (prop.dataType == 'date') {
       return dateToMysql(val).substring(0, 10);
-    } else if (prop.dataType == 'timestamp' || (prop.mysql && prop.mysql.dataType == 'timestamp')) {
-      var tz = this.client.config.connectionConfig.timezone;
-      return dateToMysql(val, tz);
     }
-    return dateToMysql(val);
+    var tz = this.client.config.connectionConfig.timezone;
+    return dateToMysql(val, tz);
   }
   if (prop.type === Boolean) {
     return !!val;
@@ -451,16 +454,18 @@ MySQL.prototype.fromColumnValue = function(prop, val) {
         if (!val || val == '0000-00-00 00:00:00' || val == '0000-00-00') {
           val = null;
         } else {
-          var dateString = val;
-          var tz = this.client.config.connectionConfig.timezone;
-          if (prop.dataType == 'date') {
-            dateString += ' 00:00:00';
+          if (this.settings.legacyDateTypeProcessing) {
+            val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
+          } else {
+            var dateString = val;
+            var tz = this.client.config.connectionConfig.timezone;
+            if (prop.dataType == 'date' || (prop.mysql && prop.mysql.dataType == 'date')) {
+              dateString += ' 00:00:00';
+            } else if (tz !== 'local') {
+              dateString += ' ' + tz;
+            }
+            val = new Date(dateString);
           }
-          //if datatype is timestamp and zimezone is not local - convert to proper timezone
-          if (tz !== 'local' && (prop.dataType == 'timestamp' || (prop.mysql && prop.mysql.dataType == 'timestamp'))) {
-            dateString += ' ' + tz;
-          }
-          return new Date(dateString);
         }
         break;
       case 'Boolean':

--- a/test/date_types.test.js
+++ b/test/date_types.test.js
@@ -232,7 +232,7 @@ describe('MySQL DATE, DATETTIME, TIMESTAMP types on server with non local TZ (+0
 });
 
 var prepareModel = function(tz, done) {
-  db = getSchema({timezone: tz});
+  db = getSchema({timezone: tz, legacyDateTypeProcessing:false});
   DateModel = db.define('DateModel', {
     id: {type: Number, id: 1, generated: true},
     datetimeField: {type: Date, dataType: 'datetime', null: false},


### PR DESCRIPTION
new connector option `legacyDateTypeProcessing` default `true`. set to `false` to use new behaviour as discussed in #257 and #149 