### PR TITLE
Add test case for order by random

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -554,7 +554,7 @@ MySQL.prototype.buildExpression = function(columnName, operator, operatorValue,
  */
 MySQL.prototype.buildOrderByRandom = function() {
   return 'ORDER BY RAND()';
-}
+};
 
 require('./migration')(MySQL, mysql);
 require('./discovery')(MySQL, mysql);

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -548,6 +548,14 @@ MySQL.prototype.buildExpression = function(columnName, operator, operatorValue,
       operatorValue, propertyDefinition);
 };
 
+/**
+ * Build order by random
+ * @returns {string} the order by rand() statement
+ */
+MySQL.prototype.buildOrderByRandom = function() {
+  return 'ORDER BY RAND()';
+}
+
 require('./migration')(MySQL, mysql);
 require('./discovery')(MySQL, mysql);
 require('./transaction')(MySQL, mysql);

--- a/test/init.js
+++ b/test/init.js
@@ -9,21 +9,15 @@ module.exports = require('should');
 
 var DataSource = require('loopback-datasource-juggler').DataSource;
 
-// var config = require('rc')('loopback', {test: {mysql: {}}}).test.mysql;
-// console.log(config);
+var config = require('rc')('loopback', {test: {mysql: {}}}).test.mysql;
+console.log(config);
 global.getConfig = function(options) {
   var dbConf = {
-    // host: process.env.MYSQL_HOST || config.host || 'localhost',
-    // port: process.env.MYSQL_PORT || config.port || 3306,
-    // database: 'myapp_test',
-    // username: process.env.MYSQL_USER || config.username,
-    // password: process.env.MYSQL_PASSWORD || config.password,
-    // createDatabase: true,
-    host: 'localhost',
-    port:  3306,
+    host: process.env.MYSQL_HOST || config.host || 'localhost',
+    port: process.env.MYSQL_PORT || config.port || 3306,
     database: 'myapp_test',
-    username: 'root',
-    password: 'abc123',
+    username: process.env.MYSQL_USER || config.username,
+    password: process.env.MYSQL_PASSWORD || config.password,
     createDatabase: true,
   };
 

--- a/test/init.js
+++ b/test/init.js
@@ -9,15 +9,21 @@ module.exports = require('should');
 
 var DataSource = require('loopback-datasource-juggler').DataSource;
 
-var config = require('rc')('loopback', {test: {mysql: {}}}).test.mysql;
-console.log(config);
+// var config = require('rc')('loopback', {test: {mysql: {}}}).test.mysql;
+// console.log(config);
 global.getConfig = function(options) {
   var dbConf = {
-    host: process.env.MYSQL_HOST || config.host || 'localhost',
-    port: process.env.MYSQL_PORT || config.port || 3306,
+    // host: process.env.MYSQL_HOST || config.host || 'localhost',
+    // port: process.env.MYSQL_PORT || config.port || 3306,
+    // database: 'myapp_test',
+    // username: process.env.MYSQL_USER || config.username,
+    // password: process.env.MYSQL_PASSWORD || config.password,
+    // createDatabase: true,
+    host: 'localhost',
+    port:  3306,
     database: 'myapp_test',
-    username: process.env.MYSQL_USER || config.username,
-    password: process.env.MYSQL_PASSWORD || config.password,
+    username: 'root',
+    password: 'abc123',
     createDatabase: true,
   };
 

--- a/test/mysql.test.js
+++ b/test/mysql.test.js
@@ -333,6 +333,31 @@ describe('mysql', function() {
       });
     });
 
+  it('should support order with random sorting', function(done) {
+    Post.create({id: '1', title: 'c', content: 'CCC'}, function(err) {
+      Post.create({id: '2', title: 'd', content: 'DDD'}, function(err) {
+        Post.create({id: '3', title: 'e', content: 'EEE'}, function(err) {
+          Post.find({order: 'rand'}, function(err, randomPosts1) {
+            should.not.exist(err);
+            var order1 = randomPosts1.map(function(u) { return u.id; });
+            (order1.length).should.eql(randomPosts1.length);
+            order1.should.containEql(1, 2, 3);
+            Post.find({order: 'rand'}, function(err, randomPosts2) {
+              should.not.exist(err);
+              var order2 = randomPosts2.map(function(u) { return u.id; });
+              (order2.length).should.eql(randomPosts2.length);
+              order2.should.containEql(1, 2, 3);
+              // Though it is a possibility that both order1 and order2 are equak,
+              // but probability is very low.
+              should(order1).not.eql(order2);
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
   it('should allow to find using like', function(done) {
     Post.create({title: 'My Post', content: 'Hello'}, function(err, post) {
       Post.find({where: {title: {like: 'M%st'}}}, function(err, posts) {

--- a/test/mysql.test.js
+++ b/test/mysql.test.js
@@ -337,12 +337,12 @@ describe('mysql', function() {
     Post.create({id: '1', title: 'c', content: 'CCC'}, function(err) {
       Post.create({id: '2', title: 'd', content: 'DDD'}, function(err) {
         Post.create({id: '3', title: 'e', content: 'EEE'}, function(err) {
-          Post.find({order: 'rand'}, function(err, randomPosts1) {
+          Post.find({order: '${random}'}, function(err, randomPosts1) {
             should.not.exist(err);
             var order1 = randomPosts1.map(function(u) { return u.id; });
             (order1.length).should.eql(randomPosts1.length);
             order1.should.containEql(1, 2, 3);
-            Post.find({order: 'rand'}, function(err, randomPosts2) {
+            Post.find({order: '${random}'}, function(err, randomPosts2) {
               should.not.exist(err);
               var order2 = randomPosts2.map(function(u) { return u.id; });
               (order2.length).should.eql(randomPosts2.length);


### PR DESCRIPTION
### Description
Add order by rand () for mysql connector.
tests couldn't be unified in juggler since they are code specific and they work only for 4 connectors. 

#### Related issues

connect to https://github.com/strongloop/loopback/issues/902
To test feature in pr: https://github.com/strongloop/loopback-connector/pull/102
Original PR that cannot be used since the function is completely refactored
https://github.com/strongloop/loopback-connector-mysql/pull/62

### Checklist


- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

