### PR TITLE
Add support for fractional seconds.

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -886,11 +886,6 @@ function mixinMigration(MySQL, mysql) {
     var precision = 0;
 
     if (p.precision) {
-      // The JavaScript Date-object has a maximum precision of three for Dates, so we can't save it more precisely (although MySQL supports it).
-      if (p.precision > 3) {
-        p.precision = 3;
-      }
-
       precision = Number(p.precision);
       columnType += '(' + precision + ')';
     }

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -710,7 +710,7 @@ function mixinMigration(MySQL, mysql) {
         dt = numericOptionsByType(p, dt);
         break;
       case 'Date':
-        dt = columnType(p, 'DATETIME'); // Currently doesn't need options.
+        dt = dateOptions(p, 'DATETIME'); // Has only precision as option.
         break;
       case 'Boolean':
         dt = 'TINYINT(1)';
@@ -877,6 +877,24 @@ function mixinMigration(MySQL, mysql) {
           break;
       }
     }
+    return columnType;
+  }
+
+  function dateOptions(p, columnType) {
+    columnType = columnType.toLowerCase();
+
+    var precision = 0;
+
+    if (p.precision) {
+      // The JavaScript Date-object has a maximum precision of three for Dates, so we can't save it more precisely (although MySQL supports it).
+      if (p.precision > 3) {
+        p.precision = 3;
+      }
+
+      precision = Number(p.precision);
+      columnType += '(' + precision + ')';
+    }
+
     return columnType;
   }
 

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -313,10 +313,22 @@ function dateToMysql(val) {
     fillZeros(val.getUTCDate()) + ' ' +
     fillZeros(val.getUTCHours()) + ':' +
     fillZeros(val.getUTCMinutes()) + ':' +
-    fillZeros(val.getUTCSeconds());
+    fillZeros(val.getUTCSeconds()) + '.' +
+    ms(val.getUTCMilliseconds());
 
   function fillZeros(v) {
     return v < 10 ? '0' + v : v;
+  }
+
+  function ms(v) {
+    // Javascript has a maximum precision of three in Dates, so we don't need more leading zeros.
+    if (v < 10) {
+      return '00' + v;
+    } else if (v < 100) {
+      return '0' + v;
+    } else {
+      return '' + v;
+    }
   }
 }
 
@@ -418,7 +430,7 @@ MySQL.prototype.fromColumnValue = function(prop, val) {
         if (val == '0000-00-00 00:00:00') {
           val = null;
         } else {
-          val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
+          val = new Date(val.toISOString());
         }
         break;
       case 'Boolean':


### PR DESCRIPTION
### Description
In MySQL 5.6 the support for saving fractional seconds for the DATETIME datatype was added. This pull request will add support for it to the connector.

I'm not sure about the best way to add test coverage for my changes to the current set of tests. If someone can help me with that, I will appreciate that. 😄

Note: MySQL supports a precision up to 6 digits, however this is not supported in JavaScript (it has a maximum of 3 digits). To avoid problems, I capped the maximum precision for the Date-datatype to three. If you agree with this limitation, I will add something in the README about that.

#### Related issues
#183 

### Checklist
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
