### PR TITLE
Remove String manipulations of Date objects

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -152,6 +152,13 @@ function generateOptions(settings) {
         options[p] = s[p];
       }
     }
+    // Legacy UTC Date Processing fallback - SHOULD BE TRANSITIONAL
+    if (s.legacyUtcDateProcessing === undefined) {
+      s.legacyUtcDateProcessing = true;
+    }
+    if (s.legacyUtcDateProcessing) {
+      options.timezone = 'Z';
+    }
   }
   return options;
 }
@@ -307,19 +314,6 @@ MySQL.prototype.updateOrCreate = function(model, data, options, cb) {
   this._modifyOrCreate(model, data, options, fields, cb);
 };
 
-function dateToMysql(val) {
-  return val.getUTCFullYear() + '-' +
-    fillZeros(val.getUTCMonth() + 1) + '-' +
-    fillZeros(val.getUTCDate()) + ' ' +
-    fillZeros(val.getUTCHours()) + ':' +
-    fillZeros(val.getUTCMinutes()) + ':' +
-    fillZeros(val.getUTCSeconds());
-
-  function fillZeros(v) {
-    return v < 10 ? '0' + v : v;
-  }
-}
-
 MySQL.prototype.getInsertedId = function(model, info) {
   var insertedId = info && typeof info.insertId === 'number' ?
     info.insertId : undefined;
@@ -356,7 +350,7 @@ MySQL.prototype.toColumnValue = function(prop, val) {
     if (!val.toUTCString) {
       val = new Date(val);
     }
-    return dateToMysql(val);
+    return val;
   }
   if (prop.type === Boolean) {
     return !!val;
@@ -417,8 +411,6 @@ MySQL.prototype.fromColumnValue = function(prop, val) {
         // those separate.
         if (val == '0000-00-00 00:00:00') {
           val = null;
-        } else {
-          val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
         }
         break;
       case 'Boolean':

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -352,6 +352,9 @@ MySQL.prototype.toColumnValue = function(prop, val) {
     }
     return val;
   }
+  if (prop.type.name === 'DateString') {
+    return val.when;
+  }
   if (prop.type === Boolean) {
     return !!val;
   }
@@ -405,11 +408,11 @@ MySQL.prototype.fromColumnValue = function(prop, val) {
         val = String(val);
         break;
       case 'Date':
-
+      case 'DateString':
         // MySQL allows, unless NO_ZERO_DATE is set, dummy date/time entries
         // new Date() will return Invalid Date for those, so we need to handle
         // those separate.
-        if (val == '0000-00-00 00:00:00') {
+        if (!val || val == '0000-00-00 00:00:00' || val == '0000-00-00') {
           val = null;
         }
         break;

--- a/test/datetime.test.js
+++ b/test/datetime.test.js
@@ -1,0 +1,95 @@
+// Copyright IBM Corp. 2012,2017. All Rights Reserved.
+// Node module: loopback-connector-mysql
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var DateString = require('../node_modules/loopback-datasource-juggler/lib/date-string');
+var fmt = require('util').format;
+var should = require('./init.js');
+
+var db, Person;
+describe('MySQL datetime handling', function() {
+  var personDefinition = {
+    name: String,
+    gender: String,
+    married: Boolean,
+    dob: {type: 'DateString'},
+    createdAt: {type: Date, default: Date},
+  };
+
+  // Modifying the connection timezones mid-flight is a pain,
+  // but closing the existing connection requires more effort.
+  function setConnectionTimezones(tz) {
+    db.connector.client._allConnections.forEach(function(con) {
+      con.config.timezone = tz;
+    });
+  }
+  before(function(done) {
+    db = getSchema({
+      dateStrings: true,
+    });
+    Person = db.define('Person', personDefinition, {forceId: true, strict: true});
+    db.automigrate(['Person'], done);
+  });
+
+  beforeEach(function() {
+    setConnectionTimezones('Z');
+  });
+  after(function(done) {
+    Person.destroyAll(function(err) {
+      db.disconnect(function() {
+        return done(err);
+      });
+    });
+  });
+
+  it('should allow use of DateStrings', function(done) {
+    var d = new DateString('1971-06-22');
+    return Person.create({
+      name: 'Mr. Pink',
+      gender: 'M',
+      dob: d,
+      createdAt: new Date(),
+    }).then(function(inst) {
+      return Person.findById(inst.id);
+    }).then(function(inst) {
+      inst.should.not.eql(null);
+      inst.dob.toString().should.eql(d.toString());
+      return done();
+    }).catch(function(err) {
+      return done(err);
+    });
+  });
+
+  describe('should allow use of alternate timezone settings', function() {
+    var d = new Date('1971-06-22T00:00:00.000Z');
+    testDateTime(d, '+04:00', '1971-06-22 04:00:00');
+    testDateTime(d, '-04:00', '1971-06-21 20:00:00');
+    testDateTime(d, '-11:00', '1971-06-21 13:00:00');
+    testDateTime(d, '+12:00', '1971-06-22 12:00:00');
+
+    function testDateTime(date, tz, expected) {
+      it(tz, function(done) {
+        setConnectionTimezones(tz);
+        db.settings.legacyUtcDateProcessing = false;
+        db.settings.timezone = tz;
+        var dt = new Date(date);
+        return Person.create({
+          name: 'Mr. Pink',
+          gender: 'M',
+          createdAt: dt,
+        }).then(function(inst) {
+          return Person.findById(inst.id);
+        }).then(function(inst) {
+          inst.should.not.eql(null);
+          inst.createdAt.toString().should.eql(expected);
+          return done();
+        }).catch(function(err) {
+          return done(err);
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
### Description
This is replacing PR #268 after rebase went badly.

Pull Request requested by @kjdelisle regarding #149 following my proposed solution "A" at #149 (comment).
As mentioned in the post linked above, this change allows the underlying mysqljs/mysql module to handle Date object serialization and removes the forced conversion of Dates to UTC Strings. An opt-out fallback to forced coercion to UTC is included, which was modeled after #265 from @darknos .

Previously timezone values specified in datasources.json had no effect on the underlying mysqljs/mysql module because Loopback was converting the Dates to Strings before handing off to the driver module.
With this change, timezone values specified in datasources.json provide the expected behavior only if "legacyUtcDateProcessing" is explicitly set to false in datasources.json, e.g.
"legacyUtcDateProcessing": false

This PR was made under conditions spelled out in the related issue thread #149 that I have limited time and expertise as a contributor and do not plan to personally address the test creation and documentation outlined in the action plan from @bajtos as pertains to this correction of long-standing undocumented forced coercion of Date types to UTC.

Please label: `breaking-change`, `bug` as per #149 

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #149 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
