### PR TITLE
Adding support for fractional seconds

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -723,7 +723,8 @@ function mixinMigration(MySQL, mysql) {
         dt = numericOptionsByType(p, dt);
         break;
       case 'Date':
-        dt = columnType(p, 'DATETIME'); // Currently doesn't need options.
+        dt = columnType(p, 'DATETIME');
+        dt = dateOptionsByType(p, dt);
         break;
       case 'Boolean':
         dt = 'TINYINT(1)';
@@ -890,6 +891,31 @@ function mixinMigration(MySQL, mysql) {
           break;
       }
     }
+    return columnType;
+  }
+
+  function dateOptionsByType(p, columnType) {
+    switch (columnType.toLowerCase()) {
+      default:
+      case 'date':
+        break;
+      case 'time':
+      case 'datetime':
+      case 'timestamp':
+        columnType = dateOptions(p, columnType);
+        break;
+    }
+    return columnType;
+  }
+
+  function dateOptions(p, columnType) {
+    var precision = 0;
+
+    if (p.precision) {
+      precision = Number(p.precision);
+      columnType += '(' + precision + ')';
+    }
+
     return columnType;
   }
 

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -412,7 +412,7 @@ MySQL.prototype.fromColumnValue = function(prop, val) {
         // MySQL allows, unless NO_ZERO_DATE is set, dummy date/time entries
         // new Date() will return Invalid Date for those, so we need to handle
         // those separate.
-        if (!val || val == '0000-00-00 00:00:00' || val == '0000-00-00') {
+        if (!val || /^0{4}(-00){2}( (00:){2}0{2}(\.0{1,6}){0,1}){0,1}$/.test(val)) {
           val = null;
         }
         break;

--- a/test/datetime.test.js
+++ b/test/datetime.test.js
@@ -17,6 +17,7 @@ describe('MySQL datetime handling', function() {
     married: Boolean,
     dob: {type: 'DateString'},
     createdAt: {type: Date, default: Date},
+    lastLogon: {type: Date, precision: 3, default: Date},
   };
 
   // Modifying the connection timezones mid-flight is a pain,
@@ -91,5 +92,23 @@ describe('MySQL datetime handling', function() {
         });
       });
     }
+  });
+
+  it('should allow use of fractional seconds', function(done) {
+    var d = new Date('1971-06-22T12:34:56.789Z');
+    return Person.create({
+      name: 'Mr. Pink',
+      gender: 'M',
+      lastLogon: d,
+    }).then(function(inst) {
+      return Person.findById(inst.id);
+    }).then(function(inst) {
+      inst.should.not.eql(null);
+      var lastLogon = new Date(inst.lastLogon);
+      lastLogon.toJSON().should.eql(d.toJSON());
+      return done();
+    }).catch(function(err) {
+      return done(err);
+    });
   });
 });


### PR DESCRIPTION
### Description
In MySQL 5.6 the support for saving fractional seconds for the DATETIME datatype was added. This pull request will add support for it to the connector for the use of native Date-types. The DateString-type already supports fractional seconds.

Earlier this week I posted #270, however this a a replacement based on the changes in the 4.1-release of the connector.

#### Related issues
- #183 

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
