### PR TITLE
switch long and lat vals for mysql

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -361,7 +361,7 @@ MySQL.prototype.toColumnValue = function(prop, val) {
   if (prop.type.name === 'GeoPoint') {
     return new ParameterizedSQL({
       sql: 'Point(?,?)',
-      params: [val.lat, val.lng],
+      params: [val.lng, val.lat],
     });
   }
   if (prop.type === Buffer) {
@@ -422,8 +422,8 @@ MySQL.prototype.fromColumnValue = function(prop, val) {
       case 'GeoPoint':
       case 'Point':
         val = {
-          lat: val.x,
-          lng: val.y,
+          lng: val.x,
+          lat: val.y,
         };
         break;
       case 'List':

--- a/test/datatypes.test.js
+++ b/test/datatypes.test.js
@@ -7,7 +7,7 @@
 require('./init.js');
 var assert = require('assert');
 
-var db, BlobModel, EnumModel, ANIMAL_ENUM;
+var db, BlobModel, EnumModel, ANIMAL_ENUM, City;
 var mysqlVersion;
 
 describe('MySQL specific datatypes', function() {
@@ -86,6 +86,26 @@ describe('MySQL specific datatypes', function() {
       });
     });
   });
+  it('should create a model instance with geopoint type', function(done) {
+    var city1 = {
+      name: 'North York',
+      loc: {
+        lat: 43.761539,
+        lng: -79.411079,
+      },
+    };
+    City.create(city1, function(err, res) {
+      assert.ok(!err);
+      res.loc.should.deepEqual(city1.loc);
+      res.name.should.equal(city1.name);
+      City.find({where: {name: city1.name}}, function(err, found) {
+        assert.ok(!err);
+        found[0].name.should.equal(city1.name);
+        found[0].loc.should.deepEqual(city1.loc);
+        done();
+      });
+    });
+  });
   it('should disconnect when done', function(done) {
     db.disconnect();
     done();
@@ -109,6 +129,11 @@ function setup(done) {
   BlobModel = db.define('BlobModel', {
     bin: {type: Buffer, dataType: 'blob', null: false},
     name: {type: String},
+  });
+
+  City = db.define('City', {
+    name: {type: String},
+    loc: {type: 'GeoPoint'},
   });
   query('SELECT VERSION()', function(err, res) {
     mysqlVersion = res && res[0] && res[0]['VERSION()'];


### PR DESCRIPTION
### Description

MySQL expects reverse order of latitude and longitude from the way we use it in LoopBack, so switch the order when saving and loading Point spatial type we use for Point/GeoPoint.

#### Related issues
connect to #269 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
