### PR TITLE
Allow explicit data types

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -702,6 +702,33 @@ function mixinMigration(MySQL, mysql) {
     return line;
   };
 
+  // override this function from base connector to allow mysql connector to
+  // accept dataPrecision and dataScale as column specific properties
+  MySQL.prototype.columnDataType = function(model, property) {
+    var columnMetadata = this.columnMetadata(model, property);
+    var colType = columnMetadata && columnMetadata.dataType;
+    if (colType) {
+      colType = colType.toUpperCase();
+    }
+    var prop = this.getModelDefinition(model).properties[property];
+    if (!prop) {
+      return null;
+    }
+    var colLength = columnMetadata && columnMetadata.dataLength || prop.length || prop.limit;
+    var colPrecision = columnMetadata && columnMetadata.dataPrecision;
+    var colScale = columnMetadata && columnMetadata.dataScale;
+    // info on setting column specific properties
+    // i.e dataLength, dataPrecision, dataScale
+    // https://loopback.io/doc/en/lb3/Model-definition-JSON-file.html
+    if (colType) {
+      if (colLength) return colType + '(' + colLength + ')';
+      if (colPrecision && colScale) return colType + '(' + colPrecision + ',' + colScale + ')';
+      if (colPrecision) return colType + '(' + colPrecision + ')';
+      return colType;
+    }
+    return this.buildColumnType(prop);
+  };
+
   MySQL.prototype.buildColumnType = function buildColumnType(propertyDefinition) {
     var dt = '';
     var p = propertyDefinition;
@@ -743,7 +770,9 @@ function mixinMigration(MySQL, mysql) {
 
   function columnType(p, defaultType) {
     var dt = defaultType;
-    if (p.dataType) {
+    if (p.mysql && p.mysql.dataType) {
+      dt = String(p.mysql.dataType);
+    } else if (p.dataType) {
       dt = String(p.dataType);
     }
     return dt;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "debug": "^2.1.1",
+    "lodash": "^4.17.4",
     "loopback-connector": "^4.0.0",
     "mysql": "^2.11.1",
     "strong-globalize": "^2.5.8"


### PR DESCRIPTION
Currently, mysql does not honour explicit data types specified in the model definition. It ignores the user specified column property and uses the default property type as the column type. 

connect to https://github.com/strongloop/loopback-connector-mysql/issues/281