### PR TITLE
Handle null values in inq properly

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -331,11 +331,25 @@ MySQL.prototype.getInsertedId = function(model, info) {
  * @returns {*} The escaped value of DB column
  */
 MySQL.prototype.toColumnValue = function(prop, val) {
-  if (val == null) {
-    if (prop.autoIncrement || prop.id) {
-      return new ParameterizedSQL('DEFAULT');
-    }
+  if (val === undefined && this.isNullable(prop)) {
     return null;
+  }
+  if (val === null) {
+    if (this.isNullable(prop)) {
+      return val;
+    } else {
+      try {
+        var castNull = prop.type(val);
+        if (prop.type === Object) {
+          return JSON.stringify(castNull);
+        }
+        return castNull;
+      } catch (err) {
+        //if we can't coerce null to a certain type,
+        //we just return it
+        return 'null';
+      }
+    }
   }
   if (!prop) {
     return val;


### PR DESCRIPTION
### Description
Fixes #221 
connect to connected to https://github.com/strongloop-internal/scrum-apex/issues/239

This PR is to handle `null` values in the `inq` operator for filters in MySQL properly. If the column is nullable, return `null`, otherwise try to coerce it to its type or return the string 'null'.
### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
