### PR TITLE
Honour user specific pk datatype

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -582,8 +582,8 @@ function mixinMigration(MySQL, mysql) {
         var idName = this.idName(model);
         var idProp = this.getModelDefinition(model).properties[idName];
         if (idProp.generated) {
-          sql.push(self.columnEscaped(model, idName) +
-            ' INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY');
+          sql.push(self.columnEscaped(model, idName) + ' ' +
+            self.buildColumnDefinition(model, idName) + ' AUTO_INCREMENT PRIMARY KEY');
         } else {
           idProp.nullable = false;
           sql.push(self.columnEscaped(model, idName) + ' ' +

--- a/test/migration.test.js
+++ b/test/migration.test.js
@@ -10,7 +10,7 @@ var platform = require('./helpers/platform');
 var should = require('./init');
 var Schema = require('loopback-datasource-juggler').Schema;
 
-var db, UserData, StringData, NumberData, DateData;
+var db, UserData, StringData, NumberData, DateData, SimpleEmployee;
 var mysqlVersion;
 
 describe('migrations', function() {
@@ -18,6 +18,16 @@ describe('migrations', function() {
 
   it('should run migration', function(done) {
     db.automigrate(function() {
+      done();
+    });
+  });
+
+  it('allow user specified datatype on PK', function(done) {
+    query('describe SimpleEmployee', function(err, result) {
+      should.not.exist(err);
+      should.exist(result);
+      result[0].Key.should.equal('PRI');
+      result[0].Type.should.equal('bigint(20)');
       done();
     });
   });
@@ -496,6 +506,11 @@ function setup(done) {
   DateData = db.define('DateData', {
     dateTime: {type: Date, dataType: 'datetime'},
     timestamp: {type: Date, dataType: 'timestamp'},
+  });
+
+  SimpleEmployee = db.define('SimpleEmployee', {
+    eId: {type: Number, generated: true, id: true, mysql: {dataType: 'bigint', dataLength: 20}},
+    name: {type: String},
   });
 
   query('SELECT VERSION()', function(err, res) {


### PR DESCRIPTION
### Description
Currently, the primary key in mysql connector always assumes the datatype to be of `int(11)` if the **generated** flag is true. This does not honour user specific datatypes if one decides to specify it on the model definition.

connect to https://github.com/strongloop/loopback-connector-mysql/issues/85