### PR TITLE
Remove unnecessary line causing validation fail

### DIFF
--- a/test/datatypes.test.js
+++ b/test/datatypes.test.js
@@ -111,7 +111,6 @@ describe('MySQL specific datatypes', function() {
       var updatedData = {
         type: 'Student - Basic',
         amount: 1155.77,
-        users: {},
       };
       Account.update({id: 1}, updatedData, function(err, result) {
         if (err) return done(err);


### PR DESCRIPTION
### Description
Remove L114. This is causing validation failure on `update` because the property **users** is not even defined as a property in the model definition for that test. Look [here](https://github.com/strongloop/loopback-connector-mysql/blob/fix/validation-update/test/datatypes.test.js#L37)

connect to https://github.com/strongloop/loopback-datasource-juggler/pull/1445