### PR TITLE
Use MySQL DEFAULT Clause/Constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,11 @@ For the date or timestamp types use `CURRENT_TIMESTAMP` or `now`:
   }
 }
 ```
+**NOTE**: The follow column types do **NOT** supported [MySQL Default Values](https://dev.mysql.com/doc/refman/5.7/en/data-type-defaults.html):
+- BLOB
+- TEXT
+- GEOMETRY
+- JSON
 
 ### Floating-point types
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ For the date or timestamp types use `CURRENT_TIMESTAMP` or `now`:
   }
 }
 ```
-**NOTE**: The follow column types do **NOT** supported [MySQL Default Values](https://dev.mysql.com/doc/refman/5.7/en/data-type-defaults.html):
+**NOTE**: The following column types do **NOT** supported [MySQL Default Values](https://dev.mysql.com/doc/refman/5.7/en/data-type-defaults.html):
 - BLOB
 - TEXT
 - GEOMETRY

--- a/README.md
+++ b/README.md
@@ -258,6 +258,26 @@ Use the `limit` option to alter the display width. Example:
 }
 ```
 
+### Default Clause/Constant
+Use the `default` property to have MySQL handle setting column `DEFAULT` value.
+```javascript
+"status": {
+  "type": "string",
+  "mysql": {
+    "default":"pending"
+  }
+}
+```
+For the date or timestamp types use `CURRENT_TIMESTAMP` or `now`:
+```javascript
+"last_modified": {
+  "type": "date",
+  "mysql": {
+    "default":"CURRENT_TIMESTAMP"
+  }
+}
+```
+
 ### Floating-point types
 
 For Float and Double data types, use the `precision` and `scale` options to specify custom precision. Default is (16,8). For example:

--- a/README.md
+++ b/README.md
@@ -264,7 +264,13 @@ Use the `default` property to have MySQL handle setting column `DEFAULT` value.
 "status": {
   "type": "string",
   "mysql": {
-    "default":"pending"
+    "default": "pending"
+  }
+},
+"number": {
+  "type": "number",
+  "mysql": {
+    "default": 256
   }
 }
 ```

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -701,13 +701,7 @@ function mixinMigration(MySQL, mysql) {
     var p = this.getModelDefinition(model).properties[prop];
     var line = this.columnDataType(model, prop) + ' ' +
       (this.isNullable(p) ? 'NULL' : 'NOT NULL');
-    if (typeof p.mysql !== 'undefined' && p.mysql.default && typeof p.mysql.default === 'string') {
-      line = line + ' DEFAULT ' +
-            (p.mysql.default.toUpperCase() === 'CURRENT_TIMESTAMP' || p.mysql.default.toLowerCase() === 'now' ?
-              'CURRENT_TIMESTAMP' : '"' + p.mysql.default + '"');
-      return line;
-    }
-    return line;
+    return columnDefault(p, line);
   };
 
   // override this function from base connector to allow mysql connector to
@@ -775,6 +769,28 @@ function mixinMigration(MySQL, mysql) {
     }
     return dt;
   };
+
+  function columnDefault(p, line) {
+    if (typeof p.type === 'undefined' || typeof p.type.name !== 'string') {
+      return line;
+    }
+    // Unsupported column types
+    if (['blob', 'json', 'text'].indexOf(p.type.name.toLowerCase()) !== -1) {
+      return line;
+    }
+    if (typeof p.mysql !== 'undefined' && p.mysql.default) {
+      var columnDefault = p.mysql.default;
+      if (typeof columnDefault === 'number') {
+        return line + ' DEFAULT ' + columnDefault;
+      }
+      if (typeof columnDefault === 'string') {
+        return line + ' DEFAULT ' +
+          (columnDefault.toUpperCase() === 'CURRENT_TIMESTAMP' || columnDefault.toLowerCase() === 'now' ?
+            'CURRENT_TIMESTAMP' : '"' + columnDefault + '"');
+      }
+    }
+    return line;
+  }
 
   function columnType(p, defaultType) {
     var dt = defaultType;

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -701,6 +701,12 @@ function mixinMigration(MySQL, mysql) {
     var p = this.getModelDefinition(model).properties[prop];
     var line = this.columnDataType(model, prop) + ' ' +
       (this.isNullable(p) ? 'NULL' : 'NOT NULL');
+    if (typeof p.mysql !== 'undefined' && p.mysql.default && typeof p.mysql.default === 'string') {
+      line = line + ' DEFAULT ' +
+            (p.mysql.default.toUpperCase() === 'CURRENT_TIMESTAMP' || p.mysql.default.toLowerCase() === 'now' ?
+              'CURRENT_TIMESTAMP' : '"' + p.mysql.default + '"');
+      return line;
+    }
     return line;
   };
 

--- a/test/migration.test.js
+++ b/test/migration.test.js
@@ -379,9 +379,16 @@ describe('migrations', function() {
       assert.ok(obj);
       var now = new Date();
       DefaultData.findById(obj.id, function(err, found) {
+        now.setSeconds(0);
+        found.dateTime.setSeconds(0);
+        found.timestamp.setSeconds(0);
+
         assert.equal(found.dateTime.toGMTString(), now.toGMTString());
         assert.equal(found.timestamp.toGMTString(), now.toGMTString());
-        assert.equal(found.is_admin, '0');
+        assert.equal(found.isAdmin, '0');
+        assert.equal(found.number, 256);
+        assert.equal(found.data, null);
+        assert.equal(found.text, null);
         assert.equal(found.status, 'pending');
         done();
       });
@@ -409,11 +416,29 @@ describe('migrations', function() {
           Key: '',
           Default: 'CURRENT_TIMESTAMP',
           Extra: ''},
-        is_admin: {Field: 'is_admin',
+        isAdmin: {Field: 'isAdmin',
           Type: 'tinyint(1)',
           Null: 'YES',
           Key: '',
           Default: '0',
+          Extra: ''},
+        number: {Field: 'number',
+          Type: 'int(10) unsigned',
+          Null: 'NO',
+          Key: 'MUL',
+          Default: '256',
+          Extra: ''},
+        data: {Field: 'data',
+          Type: 'longtext',
+          Null: 'YES',
+          Key: '',
+          Default: null,
+          Extra: ''},
+        text: {Field: 'text',
+          Type: 'varchar(1024)',
+          Null: 'YES',
+          Key: '',
+          Default: null,
           Extra: ''},
         status: {Field: 'status',
           Type: 'varchar(512)',
@@ -559,7 +584,11 @@ function setup(done) {
   DefaultData = db.define('DefaultData', {
     dateTime: {type: Date, dataType: 'datetime', mysql: {default: 'now'}},
     timestamp: {type: Date, dataType: 'timestamp', mysql: {default: 'CURRENT_TIMESTAMP'}},
-    is_admin: {type: Boolean, mysql: {default: '0'}},
+    isAdmin: {type: Boolean, mysql: {default: '0'}},
+    number: {type: Number, null: false, index: true, unsigned: true,
+      dataType: 'int', mysql: {default: 256}},
+    data: {type: Schema.JSON, dataType: 'longText', mysql: {default: 'Not Supported'}},
+    text: {type: Schema.Text, dataType: 'varchar', limit: 1024, mysql: {default: 'Not Supported'}},
     status: {type: String, dataType: 'varchar', mysql: {default: 'pending'}},
   });
 


### PR DESCRIPTION
### Description
Adding mysql.default option and documentation on special case for date.

fixes #318 

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- strongloop/loopback-connector-mysql#318

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
