### PR TITLE
Fixing some discovery and lookup issues

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -318,7 +318,7 @@ function mixinDiscovery(MySQL, mysql) {
           return 'Boolean';
         }
       case 'MEDIUMTEXT':
-          columnDefinition.dataLength = null;
+        columnDefinition.dataLength = null;
       case 'VARCHAR':
       case 'TINYTEXT':
       case 'LONGTEXT':

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -33,7 +33,7 @@ function mixinDiscovery(MySQL, mysql) {
         limitClause = limitClause + ',' + limit;
       }
     }
-    if (!orderBy) {
+    if (orderBy) {
       sql += ' ORDER BY ' + orderBy;
     }
     return sql + limitClause;
@@ -317,9 +317,10 @@ function mixinDiscovery(MySQL, mysql) {
           // Treat char(1) as boolean  ('Y', 'N', 'T', 'F', '0', '1')
           return 'Boolean';
         }
+      case 'MEDIUMTEXT':
+          columnDefinition.dataLength = null;
       case 'VARCHAR':
       case 'TINYTEXT':
-      case 'MEDIUMTEXT':
       case 'LONGTEXT':
       case 'TEXT':
       case 'ENUM':

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -118,7 +118,7 @@ function generateOptions(settings) {
   s.timezone = (s.timezone || 'local');
 
   if (isNaN(s.connectionLimit)) {
-    s.connectionLimit = 10;
+      s.connectionLimit = 100;
   }
 
   var options;
@@ -448,7 +448,8 @@ MySQL.prototype.fromColumnValue = function(prop, val) {
       case 'Array':
       case 'Object':
       case 'JSON':
-        if (typeof val === 'string') {
+        // Added length check to prevent parsing errors of an empty string
+        if (typeof val === 'string' && val.length) {
           val = JSON.parse(val);
         }
         break;

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -118,7 +118,7 @@ function generateOptions(settings) {
   s.timezone = (s.timezone || 'local');
 
   if (isNaN(s.connectionLimit)) {
-      s.connectionLimit = 100;
+    s.connectionLimit = 10;
   }
 
   var options;


### PR DESCRIPTION
### Description
Order by wasn't being respected in the discovery.
The MySQL type mediumtext with a length causes issues when trying to create a new table from the discovered schema. I fixed it on the export but there should possibly be a check on the table creation to not include a length for a mediumtext column.
Last thing was JSON.parse was throwing errors when trying to parse and empty string. Just added a check to help prevent this issue.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

N/A

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
