### PR TITLE
Lock versions of loopback-connector and mysql

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "async": "^0.9.0",
     "debug": "^3.1.0",
     "lodash": "^4.17.4",
-    "loopback-connector": "^4.0.0",
-    "mysql": "^2.11.1",
+    "loopback-connector": "4.3.0",
+    "mysql": "2.14.1",
     "strong-globalize": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description
I started getting this error unless I locked down the versions of loopback-connector and mysql.  The new versions of loopback-connector 4.4.0 and mysql 2.15.0 were giving me an error along the lines of:
-----------------------------------------------------------------------------------
>> Generated Angular services file "client/app/core/shared/services/lbServices.js"
[SyntaxError: Cannot create data source "jess": /home/ubuntu/amp/node_modules/loopback-connector-mysql/node_modules/os-locale/index.js:2
const execa = require('execa');
^^^^^
Use of const in strict mode.]
-----------------------------------------------------------------------------------
When I compared to a different environment where my app works I noticed the difference in the version of the dependent modules.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
