### PR TITLE
#362 fix bug Foreign key constraint is incorrectly formed

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -561,10 +561,12 @@ function mixinMigration(MySQL, mysql) {
 
       // verify that the other model in the same DB
       if (this._models[fkEntityName]) {
+        let entityKey = expectedColNameForModel(fk.entityKey, this.getModelDefinition(fkEntityName));
+
         return ' CONSTRAINT ' + this.client.escapeId(fk.name) +
           ' FOREIGN KEY (`' + expectedColNameForModel(fk.foreignKey, definition) + '`)' +
           ' REFERENCES ' + this.tableEscaped(fkEntityName) +
-          '(' + this.client.escapeId(fk.entityKey) + ')';
+          '(' + this.client.escapeId(entityKey) + ')';
       }
     }
     return '';


### PR DESCRIPTION
The issue #362 is fixed.
After checking in MySQL by command `SHOW ENGINE INNODB STATUS;`, I got the reason.
<pre>
LATEST FOREIGN KEY ERROR
------------------------
2018-09-17 10:40:11 0x7f2eb41b9700 Error in foreign key constraint of table `dbname`.`Book`:
Alter  table `lbmysql`.`Book` with foreign key constraint failed. Parse error in ' FOREIGN KEY (`author_id`) REFERENCES `Author`(`aId`)' near '`aId`)'.
</pre>

We forgot get the MySQL column name before building the Foreign key.
