### PR TITLE
chore: update mocha to 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "pretest": "node pretest.js",
     "lint": "eslint .",
-    "test": "mocha --timeout 10000  test/*.test.js node_modules/juggler-v3/test.js node_modules/juggler-v4/test.js",
+    "test": "mocha --timeout 10000  test/*.test.js node_modules/juggler-v3/test.js node_modules/juggler-v4/test.js --exit",
     "posttest": "npm run lint"
   },
   "dependencies": {
@@ -27,7 +27,7 @@
     "juggler-v3": "file:./deps/juggler-v3",
     "juggler-v4": "file:./deps/juggler-v4",
     "loopback-datasource-juggler": "^3.0.0 || ^4.0.0",
-    "mocha": "^2.1.0",
+    "mocha": "^5.2.0",
     "rc": "^1.0.0",
     "should": "^8.0.2",
     "sinon": "^1.15.4"

--- a/test/datetime.test.js
+++ b/test/datetime.test.js
@@ -46,7 +46,7 @@ describe('MySQL datetime handling', function() {
     });
   });
 
-  it('should allow use of DateStrings', function(done) {
+  it('should allow use of DateStrings', function() {
     var d = new DateString('1971-06-22');
     return Person.create({
       name: 'Mr. Pink',
@@ -58,9 +58,6 @@ describe('MySQL datetime handling', function() {
     }).then(function(inst) {
       inst.should.not.eql(null);
       inst.dob.toString().should.eql(d.toString());
-      return done();
-    }).catch(function(err) {
-      return done(err);
     });
   });
 
@@ -72,7 +69,7 @@ describe('MySQL datetime handling', function() {
     testDateTime(d, '+12:00', '1971-06-22 12:00:00');
 
     function testDateTime(date, tz, expected) {
-      it(tz, function(done) {
+      it(tz, function() {
         setConnectionTimezones(tz);
         db.settings.legacyUtcDateProcessing = false;
         db.settings.timezone = tz;
@@ -86,15 +83,12 @@ describe('MySQL datetime handling', function() {
         }).then(function(inst) {
           inst.should.not.eql(null);
           inst.createdAt.toString().should.eql(expected);
-          return done();
-        }).catch(function(err) {
-          return done(err);
         });
       });
     }
   });
 
-  it('should allow use of fractional seconds', function(done) {
+  it('should allow use of fractional seconds', function() {
     var d = new Date('1971-06-22T12:34:56.789Z');
     return Person.create({
       name: 'Mr. Pink',
@@ -106,9 +100,6 @@ describe('MySQL datetime handling', function() {
       inst.should.not.eql(null);
       var lastLogon = new Date(inst.lastLogon);
       lastLogon.toJSON().should.eql(d.toJSON());
-      return done();
-    }).catch(function(err) {
-      return done(err);
     });
   });
 });


### PR DESCRIPTION
### Description
Update mocha to latest major version. Fix promise based tests to conform to expectation (see https://mochajs.org/#working-with-promises). Added the `--exit` flag based on https://boneskull.com/mocha-v4-nears-release/#mochawontforceexit and the result from `wtfnode` module after running the tests with it (`wtfnode ./node_modules/.bin/mocha --timeout 10000 --require test/init.js test/*.js`):
```
^C[WTF Node?] open handles:
- File descriptors: (note: stdio always exists)
  - fd 1 (tty) (stdio)
  - fd 2 (tty) (stdio)
```
I couldn't see anything suspicious from our tests, so decided to use the flag for pre-v4 behaviour.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
