### PR TITLE
 Fix AUTO_INCREMENT for complex PK

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -640,7 +640,11 @@ function mixinMigration(MySQL, mysql) {
           return;
         }
         var colName = self.columnEscaped(model, prop);
-        sql.push(colName + ' ' + self.buildColumnDefinition(model, prop));
+
+        if (definition.properties[prop].generated)
+          sql.push(colName + ' ' + self.buildColumnDefinition(model, prop) + ' AUTO_INCREMENT ');
+        else
+          sql.push(colName + ' ' + self.buildColumnDefinition(model, prop));
       });
       if (pks.length > 1) {
         sql.push('PRIMARY KEY(' + pks.join(',') + ')');


### PR DESCRIPTION
### Description

In case we are use complex primary keys, one or many of them can be auto incremented fields. So I think need to add AUTO_INCREMENT without check PRIMIRY is simple or complex.
