### PR TITLE
Default value improvments

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -821,16 +821,25 @@ function mixinMigration(MySQL, mysql) {
     if (['blob', 'json', 'text'].indexOf(p.type.name.toLowerCase()) !== -1) {
       return line;
     }
-    if (typeof p.mysql !== 'undefined' && p.mysql.default) {
-      var columnDefault = p.mysql.default;
-      if (typeof columnDefault === 'number') {
-        return line + ' DEFAULT ' + columnDefault;
-      }
-      if (typeof columnDefault === 'string') {
-        return line + ' DEFAULT ' +
-          (columnDefault.toUpperCase() === 'CURRENT_TIMESTAMP' || columnDefault.toLowerCase() === 'now' ?
-            'CURRENT_TIMESTAMP' : '"' + columnDefault + '"');
-      }
+    var columnDefault = p.default;
+
+    if (typeof p.mysql !== 'undefined' && typeof p.mysql.default !== 'undefined')
+      columnDefault = p.mysql.default;
+
+    if (typeof columnDefault === 'boolean') 
+      return line + ' DEFAULT ' + Number(columnDefault);
+
+    if (typeof columnDefault === 'number') 
+      return line + ' DEFAULT ' + columnDefault;
+    
+    if (typeof columnDefault === 'string') {
+      if (columnDefault.toLowerCase() === '$now')
+        return line;
+        
+      return line + ' DEFAULT ' +
+        (columnDefault.toUpperCase() === 'CURRENT_TIMESTAMP' ||
+          columnDefault.toLowerCase() === 'now' ?
+          'CURRENT_TIMESTAMP' : '"' + columnDefault + '"');
     }
     return line;
   }


### PR DESCRIPTION
### Description

MySQL server doesn't support boolean, but has bit, tinyint etc. 
Additional we can use empty default value, for example '' for strings, or 0 for int.  
The older code checks type of default value by type any way, so I think we can improve this case for:
 - boolean types
 - empty or 0 value
 - add support 'default' from generic properties (Like Postgres for example)
