### PR TITLE
fix a bug in index creation

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -406,10 +406,11 @@ function mixinMigration(MySQL, mysql) {
         // if indexes are configured as "keys"
         if (i.keys) {
           for (var key in i.keys) {
+            var escapedKey = '`'+key+'`';
             if (i.keys[key] !== -1) {
-              indexedColumns.push(key);
+              indexedColumns.push(escapedKey);
             } else {
-              indexedColumns.push(key + ' DESC ');
+              indexedColumns.push(escapedKey + ' DESC ');
             }
           }
         }

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -406,7 +406,7 @@ function mixinMigration(MySQL, mysql) {
         // if indexes are configured as "keys"
         if (i.keys) {
           for (var key in i.keys) {
-            var escapedKey = '`'+key+'`';
+            var escapedKey = '`' + key + '`';
             if (i.keys[key] !== -1) {
               indexedColumns.push(escapedKey);
             } else {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -406,7 +406,7 @@ function mixinMigration(MySQL, mysql) {
         // if indexes are configured as "keys"
         if (i.keys) {
           for (var key in i.keys) {
-            var escapedKey = '`' + key + '`';
+            var escapedKey = self.client.escapeId(key);
             if (i.keys[key] !== -1) {
               indexedColumns.push(escapedKey);
             } else {


### PR DESCRIPTION
### Description
Just added backtick before and after each field on the "add index" statement
Without this patch the SQL statement looks like
```
ALTER TABLE `[table_name]` ADD [UNIQUE] INDEX  `[index_name]` ([field])
```
with this patch the statement become
```
ALTER TABLE `[table_name]` ADD [UNIQUE] INDEX  `[index_name]` (`[field]`)
```
### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
