### PR TITLE
 处理bit(1)无法转换成boolean-resolve bit(1) can't be boolean

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -435,7 +435,10 @@ MySQL.prototype.fromColumnValue = function(prop, val) {
         }
         break;
       case 'Boolean':
-        val = Boolean(val);
+        val = Boolean(val);	        // BIT(1) case: <Buffer 01> for true and <Buffer 00> for false
+        // CHAR(1) case: '1' for true and '0' for false
+        // TINYINT(1) case: 1 for true and 0 for false
+        val = Buffer.isBuffer(val) ? Boolean(val[0]) : Boolean(parseInt(val));
         break;
       case 'GeoPoint':
       case 'Point':


### PR DESCRIPTION
默认的5.3还是有问题,所以我自己处理

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mysql) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
