### PR TITLE
chore: update copyrights year

### DIFF
--- a/deps/juggler-v3/test.js
+++ b/deps/juggler-v3/test.js
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
-// This file is licensed under the Artistic License 2.0.
-// License text available at https://opensource.org/licenses/Artistic-2.0
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 

--- a/deps/juggler-v4/test.js
+++ b/deps/juggler-v4/test.js
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
-// This file is licensed under the Artistic License 2.0.
-// License text available at https://opensource.org/licenses/Artistic-2.0
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
 'use strict';
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2012,2016. All Rights Reserved.
+// Copyright IBM Corp. 2012,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2012,2017. All Rights Reserved.
+// Copyright IBM Corp. 2012,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/set-http-code.js
+++ b/lib/set-http-code.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/pretest.js
+++ b/pretest.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/datatypes.test.js
+++ b/test/datatypes.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/datetime.test.js
+++ b/test/datetime.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2017,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/helpers/platform.js
+++ b/test/helpers/platform.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016,2017. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/init.js
+++ b/test/init.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/migration.test.js
+++ b/test/migration.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/mysql.autoupdate.test.js
+++ b/test/mysql.autoupdate.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2018. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/mysql.discover.test.js
+++ b/test/mysql.discover.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/mysql.test.js
+++ b/test/mysql.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/set-http-code.test.js
+++ b/test/set-http-code.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/transaction.promise.test.js
+++ b/test/transaction.promise.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2017. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2017. All Rights Reserved.
+// Copyright IBM Corp. 2015,2019. All Rights Reserved.
 // Node module: loopback-connector-mysql
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Related: strongloop-internal/scrum-apex#440

Update the copyrights year in the rest of the packages besides #4596.

The changes are introduced by running the `slt copyright` command. I'm skipping the fixtures folders.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mysql) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
