### PR TITLE
Fix bug #424

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1022,6 +1022,8 @@ function mixinMigration(MySQL, mysql) {
     return columnType;
   }
   function expectedColNameForModel(propName, modelToCheck) {
+    if (typeof modelToCheck.properties[propName] == 'undefined')
+      return propName;
     var mysql = modelToCheck.properties[propName].mysql;
     if (typeof mysql === 'undefined') {
       return propName;


### PR DESCRIPTION
Fix bug if the propName doesn't have the same name of the foreign key during the migration
See the issue #424 for more details.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mysql) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
