### PR TITLE
fix: allow to generate foreign key constraint with custom fk name

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1022,14 +1022,16 @@ function mixinMigration(MySQL, mysql) {
     return columnType;
   }
   function expectedColNameForModel(propName, modelToCheck) {
-    var mysql = modelToCheck.properties[propName].mysql;
-    if (typeof mysql === 'undefined') {
-      return propName;
+    if (modelToCheck.properties[propName].mysql) {
+      var mysql = modelToCheck.properties[propName].mysql;
+      if (typeof mysql === 'undefined') {
+        return propName;
+      }
+      var colName = mysql.columnName;
+      if (typeof colName !== 'undefined') {
+        return colName;
+      }
     }
-    var colName = mysql.columnName;
-    if (typeof colName === 'undefined') {
-      return propName;
-    }
-    return colName;
+    return propName;
   }
 }


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Fixes https://github.com/strongloop/loopback-connector-mysql/issues/424

Fixes the issue that the fk constraint cannot be generated if the fk name is customized.

Once it is fixed, we only need to specify the custom name in the **property definition** and use the property name as is in the foreign key constraint settings. E.g:
```ts
@model({
  settings:{
    'foreignKeys': {
      'fk_customer_customerId': {
        'name': 'fk_customert_customerId',
        'entity': 'Customer',
        'entityKey': 'id',
        'foreignKey': 'customerId', // property name
      },
  }
})
export class Order extends Entity {
  @property({
    type: 'number',
    id: true,
    generated: true,
  })
  id?: number;

  @belongsTo(() => Customer,
    {},
    {mysql:{columnName: 'MY_FK'}} // custom name
    )
  customerId: number;
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mysql) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
