### PR TITLE
fix(docs): Specify table creation order method

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,14 @@ type, you can:
 Foreign key constraints can be defined in the model definition.
 
 **Note**: The order of table creation is important. A referenced table must
-exist before creating a foreign key constraint.
+exist before creating a foreign key constraint. The order can be specified 
+using the optional <a href="https://loopback.io/doc/en/lb4/apidocs.repository.schemamigrationoptions.html">`SchemaMigrationOptions`</a> argument of `migrateSchema`:
+
+```
+await app.migrateSchema({
+	models: [ 'Customer', 'Order' ]
+});
+```
 
 Define your models and the foreign key constraints as follows:
 


### PR DESCRIPTION
Signed-off-by: Roderik van Heijst <rvanheijst@0x0a.nl>

Fixes #443 

Added explanation of how to specify the order of table creation with a link to `SchemaMigrationOptions`.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html) (I hope!)
